### PR TITLE
New Checker for Renegade assertTrue/False

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Calen Pennington <calen.pennington@gmail.com>
 Ned Batchelder <ned@nedbatchelder.com>
+Michael Sverdlin <m@sveder.com>

--- a/edx_lint/pylint/plugin.py
+++ b/edx_lint/pylint/plugin.py
@@ -1,6 +1,6 @@
 from edx_lint.pylint import (
     getattr_check, i18n_check, module_trace, range_check, super_check,
-    layered_test_check,
+    layered_test_check, right_assert_check
 )
 
 
@@ -11,6 +11,6 @@ def register(linter):
     # add all of the checkers
     for mod in [
         getattr_check, i18n_check, module_trace, range_check, super_check,
-        layered_test_check,
+        layered_test_check, right_assert_check,
     ]:
         mod.register_checkers(linter)

--- a/edx_lint/pylint/right_assert_check.py
+++ b/edx_lint/pylint/right_assert_check.py
@@ -28,30 +28,16 @@ class AssertChecker(BaseChecker):
 
     AFFECTED_ASSERTS = ["assertTrue", "assertFalse"]
 
-    USE_ASSERT_EQUAL = 'wrong-assert-should-be-assertequal'
-    USE_ASSERT_IN = 'wrong-assert-should-be-assertin'
-    USE_ASSERT_COMPARE = 'wrong-assert-should-be-assertcomparison'
+    MESSAGE_ID = 'wrong-assert-type'
     msgs = {
         'C%d90' % BASE_ID: (
-            "%s is a comparison, use assertEqual.",
-            USE_ASSERT_EQUAL,
-             "Use assert(Not)Equal instead of assertTrue/False",
-        ),
-
-        'C%d91' % BASE_ID: (
-            "%s is an in statement, use assertIn.",
-            USE_ASSERT_IN,
-            "Use assert(Not)In instead of assertTrue/False.",
-        ),
-
-        'C%d92' % BASE_ID: (
-            "%s is a comparison, use assertGreater or assertLess.",
-            USE_ASSERT_COMPARE,
-            "Use assertGreater/Less instead of assertTrue/False",
+            "%s",
+            MESSAGE_ID,
+            "Use assert(Not)Equal instead of assertTrue/False",
         ),
     }
 
-    @utils.check_messages(USE_ASSERT_EQUAL, USE_ASSERT_IN, USE_ASSERT_COMPARE)
+    @utils.check_messages(MESSAGE_ID)
     def visit_callfunc(self, node):
         """
         Check that various assertTrue/False functions are not misused.
@@ -71,12 +57,21 @@ class AssertChecker(BaseChecker):
 
         if first_arg.ops[0][0] in ["==", "!="]:
             # An assertTrue/False with a compare should be assertEqual:
-            self.add_message(self.USE_ASSERT_EQUAL, args=first_arg.as_string(), node=node)
+            self.add_message(self.MESSAGE_ID,
+                             args="%s(%s) should be assertEqual or assertNotEqual" % (node.func.attrname,
+                                                                                      first_arg.as_string()),
+                             node=node)
 
-        elif first_arg.ops[0][0] == "in":
+        elif first_arg.ops[0][0] in ["in", "not in"]:
             # An assertTrue/False with an in statement should be assertIn:
-            self.add_message(self.USE_ASSERT_IN, args=first_arg.as_string(), node=node)
+            self.add_message(self.MESSAGE_ID,
+                             args="%s(%s) should be assertIn or assertNotIn" % (node.func.attrname,
+                                                                                first_arg.as_string()),
+                             node=node)
 
         elif "<" in first_arg.ops[0][0] or ">" in first_arg.ops[0][0]:
             # An assertTrue/False with a comparison should be assertGreater or assertLess:
-            self.add_message(self.USE_ASSERT_COMPARE, args=first_arg.as_string(), node=node)
+            self.add_message(self.MESSAGE_ID,
+                             args="%s(%s) should be assertGreater or assertLess" % (node.func.attrname,
+                                                                                    first_arg.as_string()),
+                             node=node)

--- a/edx_lint/pylint/right_assert_check.py
+++ b/edx_lint/pylint/right_assert_check.py
@@ -1,0 +1,82 @@
+"""Checker for using assertTrue/False instead of a more precise assert.
+
+Hattip to Ned Batchelder for the idea:
+http://nedbatchelder.com/blog/201505/writing_pylint_plugins.html
+"""
+import astroid
+
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker, utils
+
+from .common import BASE_ID
+
+
+def register_checkers(linter):
+    """Register checkers."""
+    linter.register_checker(AssertChecker(linter))
+
+
+class AssertChecker(BaseChecker):
+    """
+    Implements a few pylint checks on unitests asserts - making sure the right assert is used if assertTrue or
+    assertFalse are misused.
+    """
+
+    __implements__ = (IAstroidChecker,)
+
+    name = 'assert-checker'
+
+    AFFECTED_ASSERTS = ["assertTrue", "assertFalse"]
+
+    USE_ASSERT_EQUAL = 'wrong-assert-should-be-assertequal'
+    USE_ASSERT_IN = 'wrong-assert-should-be-assertin'
+    USE_ASSERT_COMPARE = 'wrong-assert-should-be-assertcomparison'
+    msgs = {
+        'C%d90' % BASE_ID: (
+            "%s is a comparison, use assertEqual.",
+            USE_ASSERT_EQUAL,
+             "Use assert(Not)Equal instead of assertTrue/False",
+        ),
+
+        'C%d91' % BASE_ID: (
+            "%s is an in statement, use assertIn.",
+            USE_ASSERT_IN,
+            "Use assert(Not)In instead of assertTrue/False.",
+        ),
+
+        'C%d92' % BASE_ID: (
+            "%s is a comparison, use assertGreater or assertLess.",
+            USE_ASSERT_COMPARE,
+            "Use assertGreater/Less instead of assertTrue/False",
+        ),
+    }
+
+    @utils.check_messages(USE_ASSERT_EQUAL, USE_ASSERT_IN, USE_ASSERT_COMPARE)
+    def visit_callfunc(self, node):
+        """
+        Check that various assertTrue/False functions are not misused.
+        """
+        if not isinstance(node.func, astroid.Getattr):
+            # If it isn't a getattr ignore this. All the assertMethods are attrs of self:
+            return
+
+        if node.func.attrname not in self.AFFECTED_ASSERTS:
+            # Not an attribute / assert we care about
+            return
+
+        first_arg = node.args[0]
+        if not isinstance(first_arg, astroid.Compare):
+            # Not a comparison, so this is probably ok:
+            return
+
+        if first_arg.ops[0][0] in ["==", "!="]:
+            # An assertTrue/False with a compare should be assertEqual:
+            self.add_message(self.USE_ASSERT_EQUAL, args=first_arg.as_string(), node=node)
+
+        elif first_arg.ops[0][0] == "in":
+            # An assertTrue/False with an in statement should be assertIn:
+            self.add_message(self.USE_ASSERT_IN, args=first_arg.as_string(), node=node)
+
+        elif "<" in first_arg.ops[0][0] or ">" in first_arg.ops[0][0]:
+            # An assertTrue/False with a comparison should be assertGreater or assertLess:
+            self.add_message(self.USE_ASSERT_COMPARE, args=first_arg.as_string(), node=node)

--- a/test/input/func_asserts_check.py
+++ b/test/input/func_asserts_check.py
@@ -30,10 +30,10 @@ class TestStringMethods(unittest.TestCase):
         right_assert should throw an error for each line here.
         """
         self.assertTrue('foo'.upper() == 'FOO')
-        self.assertFalse(500 != 500)
+        self.assertFalse(500 == 501)
 
         self.assertTrue("a" in "lala")
-        self.assertFalse("b" in "lala")
+        self.assertFalse("b" not in "lala")
 
         self.assertTrue(1 > 0)
-        self.assertFalse(1 > 2)
+        self.assertFalse(1 < 2)

--- a/test/input/func_asserts_check.py
+++ b/test/input/func_asserts_check.py
@@ -1,0 +1,39 @@
+"""
+Test for the right_assert pylint plugin.
+"""
+import unittest
+
+
+class TestStringMethods(unittest.TestCase):
+    """
+    Test class for the right_assert pylint plugin.
+    """
+    def test_right_usage(self):
+        """
+        This is the right usage of various assert functions.
+        """
+        self.assertEqual('foo'.upper(), 'FOO')
+
+        true = True
+        self.assertTrue(true)
+        self.assertFalse(not true)
+
+        self.assertIn("a", "lala")
+        self.assertNotIn("b", "lala")
+
+        self.assertGreater(1, 0)
+        self.assertLess(1, 2)
+
+    def test_wrong_usage(self):
+        """
+        This is the wrong usage of assertTrue and False, but test should still pass.
+        right_assert should throw an error for each line here.
+        """
+        self.assertTrue('foo'.upper() == 'FOO')
+        self.assertFalse(500 != 500)
+
+        self.assertTrue("a" in "lala")
+        self.assertFalse("b" in "lala")
+
+        self.assertTrue(1 > 0)
+        self.assertFalse(1 > 2)

--- a/test/messages/func_asserts_check.txt
+++ b/test/messages/func_asserts_check.txt
@@ -1,6 +1,6 @@
-C: 32:TestStringMethods.test_wrong_usage: 'foo'.upper() == 'FOO' is a comparison, use assertEqual.
-C: 33:TestStringMethods.test_wrong_usage: 500 != 500 is a comparison, use assertEqual.
-C: 35:TestStringMethods.test_wrong_usage: 'a' in 'lala' is an in statement, use assertIn.
-C: 36:TestStringMethods.test_wrong_usage: 'b' in 'lala' is an in statement, use assertIn.
-C: 38:TestStringMethods.test_wrong_usage: 1 > 0 is a comparison, use assertGreater or assertLess.
-C: 39:TestStringMethods.test_wrong_usage: 1 > 2 is a comparison, use assertGreater or assertLess.
+C: 32:TestStringMethods.test_wrong_usage: assertTrue('foo'.upper() == 'FOO') should be assertEqual or assertNotEqual
+C: 33:TestStringMethods.test_wrong_usage: assertFalse(500 == 501) should be assertEqual or assertNotEqual
+C: 35:TestStringMethods.test_wrong_usage: assertTrue('a' in 'lala') should be assertIn or assertNotIn
+C: 36:TestStringMethods.test_wrong_usage: assertFalse('b' not in 'lala') should be assertIn or assertNotIn
+C: 38:TestStringMethods.test_wrong_usage: assertTrue(1 > 0) should be assertGreater or assertLess
+C: 39:TestStringMethods.test_wrong_usage: assertFalse(1 < 2) should be assertGreater or assertLess

--- a/test/messages/func_asserts_check.txt
+++ b/test/messages/func_asserts_check.txt
@@ -1,0 +1,6 @@
+C: 32:TestStringMethods.test_wrong_usage: 'foo'.upper() == 'FOO' is a comparison, use assertEqual.
+C: 33:TestStringMethods.test_wrong_usage: 500 != 500 is a comparison, use assertEqual.
+C: 35:TestStringMethods.test_wrong_usage: 'a' in 'lala' is an in statement, use assertIn.
+C: 36:TestStringMethods.test_wrong_usage: 'b' in 'lala' is an in statement, use assertIn.
+C: 38:TestStringMethods.test_wrong_usage: 1 > 0 is a comparison, use assertGreater or assertLess.
+C: 39:TestStringMethods.test_wrong_usage: 1 > 2 is a comparison, use assertGreater or assertLess.


### PR DESCRIPTION
This is another Pylint checker that checks that comparisons aren't done inside of assertTrue/False, for example:
```
assertTrue(x == y) 
```
should be:
```
assertEqual(x, y)
```

I've started it here:
https://github.com/Sveder/custom-lints
and after email discussion with Ned Batchelder we agreed that it is a right fit to the edx-lint repo. 
