### PR TITLE
Allow "class Meta" with no docstring.

### DIFF
--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -144,7 +144,7 @@ bad-names=foo,bar,baz,toto,tutu,tata
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=__.*__|test_.+|setUp|tearDown
+no-docstring-rgx=__.*__$|test_.+|setUp$|setUpClass$|tearDown$|tearDownClass$|Meta$
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.


### PR DESCRIPTION
Also, pin the ends of the regex to be stricter.