### PR TITLE
Make edx-lint commands work with both python2 and python3

### DIFF
--- a/edx_lint/cmd/check.py
+++ b/edx_lint/cmd/check.py
@@ -1,4 +1,5 @@
 """The edx_lint check command."""
+from __future__ import print_function
 
 import os
 
@@ -7,19 +8,19 @@ from edx_lint.tamper_evident import TamperEvidentFile
 
 def check_main(argv):
     if len(argv) != 1:
-        print "Please provide the name of a file to check."
+        print("Please provide the name of a file to check.")
         return 1
 
     filename = argv[0]
 
     if os.path.exists(filename):
-        print "Checking existing copy of %s" % filename
+        print("Checking existing copy of %s" % filename)
         tef = TamperEvidentFile(filename)
         if tef.validate():
-            print "Your copy of %s is good" % filename
+            print("Your copy of %s is good" % filename)
         else:
-            print "Your copy of %s seems to have been edited" % filename
+            print("Your copy of %s seems to have been edited" % filename)
     else:
-        print "You don't have a copy of %s" % filename
+        print("You don't have a copy of %s" % filename)
 
     return 0

--- a/edx_lint/cmd/list.py
+++ b/edx_lint/cmd/list.py
@@ -1,11 +1,12 @@
 """The edx_lint list command."""
+from __future__ import print_function
 
 import pkg_resources
 
 
 def list_main(argv_unused):
-    print "edx_lint knows about these files:"
+    print("edx_lint knows about these files:")
     for filename in pkg_resources.resource_listdir("edx_lint", "files"):
-        print filename
+        print(filename)
 
     return 0

--- a/edx_lint/cmd/main.py
+++ b/edx_lint/cmd/main.py
@@ -1,4 +1,5 @@
 """The edx_lint command."""
+from __future__ import print_function
 
 import sys
 
@@ -20,12 +21,12 @@ def main(argv=None):
     elif argv[0] == "write":
         return write_main(argv[1:])
     else:
-        print "Don't understand {!r}".format(" ".join(argv))
+        print("Don't understand {!r}".format(" ".join(argv)))
         help()
 
 
 def help():
-    print """\
+    print("""\
 Manage local config files from masters in edx_lint.
 
 Commands:
@@ -37,4 +38,4 @@ Commands:
 
     list
         List the FILENAMEs that edx_lint can provide.
-"""
+""")

--- a/edx_lint/tamper_evident.py
+++ b/edx_lint/tamper_evident.py
@@ -15,7 +15,7 @@ class TamperEvidentFile(object):
     def __init__(self, filename):
         self.filename = filename
 
-    def write(self, text, hashline=b"# {}"):
+    def write(self, text, hashline=u"# {}"):
         """
         Write `text` to the file.
 
@@ -26,21 +26,21 @@ class TamperEvidentFile(object):
         be changed to accommodate different file syntaxes.
 
         Arguments:
-            text (byte string): the contents of the file to write.
+            text (unicode string): the contents of the file to write.
 
-            hashline (byte string): the format of the last line to append to
+            hashline (unicode string): the format of the last line to append to
                 the file, with "{}" replaced with the hash.
 
         """
-        if not text.endswith(b"\n"):
-            text += b"\n"
+        if not text.endswith(u"\n"):
+            text += u"\n"
 
-        hash = hashlib.sha1(text).hexdigest()
+        hash = hashlib.sha1(text.encode("ascii")).hexdigest()
 
-        with open(self.filename, "wb") as f:
+        with open(self.filename, "w") as f:
             f.write(text)
-            f.write(hashline.decode("ascii").format(hash).encode("ascii"))
-            f.write(b"\n")
+            f.write(hashline.format(hash))
+            f.write(u"\n")
 
     def validate(self):
         """
@@ -50,10 +50,10 @@ class TamperEvidentFile(object):
         with.
         """
 
-        with open(self.filename, "rb") as f:
+        with open(self.filename, "r") as f:
             text = f.read()
 
-        start_last_line = text.rfind(b"\n", 0, -1)
+        start_last_line = text.rfind(u"\n", 0, -1)
         if start_last_line == -1:
             return False
 
@@ -61,7 +61,7 @@ class TamperEvidentFile(object):
         last_line = text[start_last_line+1:]
 
         expected_hash = hashlib.sha1(original_text).hexdigest().encode("ascii")
-        match = re.search(br"[0-9a-f]{40}", last_line)
+        match = re.search(r"[0-9a-f]{40}", last_line)
         if not match:
             return False
         actual_hash = match.group(0)


### PR DESCRIPTION
@nedbat, @clintonb: I had to make these changes to make it so that the IDA cookiecutter could run in both python2 and python3 virtualenvs.