### PR TITLE
Remove deprecation warnings

### DIFF
--- a/edx_lint/pylint/layered_test_check.py
+++ b/edx_lint/pylint/layered_test_check.py
@@ -1,6 +1,7 @@
 """Pylint plugin: test classes derived from test classes."""
 
 import astroid
+from astroid.scoped_nodes import get_locals     # not sure this is the right import
 
 from pylint.checkers import BaseChecker, utils
 from pylint.interfaces import IAstroidChecker
@@ -41,7 +42,7 @@ class LayeredTestClassChecker(BaseChecker):
         if not node.is_subtype_of('unittest.case.TestCase'):
             return False
 
-        dunder_test = node.locals.get("__test__")
+        dunder_test = get_locals(node).get("__test__")
         if dunder_test:
             if isinstance(dunder_test[0], astroid.AssName):
                 value = list(dunder_test[0].assigned_stmts())

--- a/edx_lint/pylint/right_assert_check.py
+++ b/edx_lint/pylint/right_assert_check.py
@@ -76,7 +76,7 @@ class AssertChecker(BaseChecker):
         """
         Check that various assertTrue/False functions are not misused.
         """
-        if not isinstance(node.func, astroid.Getattr):
+        if not isinstance(node.func, astroid.Attribute):
             # If it isn't a getattr ignore this. All the assertMethods are
             # attributes of self:
             return

--- a/test/test_pylint_plugins.py
+++ b/test/test_pylint_plugins.py
@@ -17,7 +17,6 @@ def load_tests(unused_loader, tests, unused_pattern):
 
     # Load our plugin.
     linter.load_plugin_modules(['edx_lint.pylint'])
-    linter.global_set_option('required-attributes', ())
 
     here = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
We had these deprecation warnings (among many others from inside pylint(!?)):
```
Warning: option required-attributes is obsolete and it is slated for removal in Pylint 1.6.
/src/edx/src/edx-lint/edx_lint/pylint/layered_test_check.py:44: PendingDeprecationWarning: locals is deprecated and will be removed in astroid 2.0, use the function 'get_locals()' instead.
  dunder_test = node.locals.get("__test__")
/src/edx/src/edx-lint/edx_lint/pylint/right_assert_check.py:79: PendingDeprecationWarning: 'Getattr' is deprecated and slated for removal in astroid 2.0, use 'Attribute' instead
  if not isinstance(node.func, astroid.Getattr):
```