### PR TITLE
Required base classes

### DIFF
--- a/edx_lint/pylint/plugin.py
+++ b/edx_lint/pylint/plugin.py
@@ -6,12 +6,12 @@ will register them with pylint.
 
 from edx_lint.pylint import (
     getattr_check, i18n_check, module_trace, range_check, super_check,
-    layered_test_check, right_assert_check,
+    layered_test_check, right_assert_check, required_base_class,
 )
 
 MODS = [
     getattr_check, i18n_check, module_trace, range_check, super_check,
-    layered_test_check, right_assert_check,
+    layered_test_check, right_assert_check, required_base_class,
 ]
 
 def register(linter):

--- a/edx_lint/pylint/required_base_class.py
+++ b/edx_lint/pylint/required_base_class.py
@@ -56,7 +56,12 @@ class RequiredBaseClassChecker(BaseChecker):
         if not self.class_map:
             return
 
-        all_bases = [usable_class_name(c) for c in node.mro()]
+        try:
+            all_bases = [usable_class_name(c) for c in node.mro()]
+        except NotImplementedError:
+            # Old-style 2.x classes have no mro.
+            all_bases = []
+
         for base in all_bases:
             required = self.class_map.get(base)
             if required is not None:

--- a/edx_lint/pylint/required_base_class.py
+++ b/edx_lint/pylint/required_base_class.py
@@ -1,0 +1,59 @@
+"""Pylint plugin: some classes have required base classes."""
+
+import collections
+
+import astroid
+from astroid.scoped_nodes import get_locals     # not sure this is the right import
+
+from pylint.checkers import BaseChecker, utils
+from pylint.interfaces import IAstroidChecker
+
+from .common import BASE_ID
+
+
+def register_checkers(linter):
+    """Register checkers."""
+    linter.register_checker(RequiredBaseClassChecker(linter))
+
+
+class RequiredBaseClassChecker(BaseChecker):
+    """Pylint checker for required base classes."""
+
+    __implements__ = (IAstroidChecker,)
+
+    name = 'required-base-class-checker'
+
+    MESSAGE_ID = "missing-required-base-class"
+    msgs = {
+        'E%d40' % BASE_ID: (
+            "class %s is missing required base class %s",
+            MESSAGE_ID,
+            "Used when a class is missing a base class required by one of its "
+            "other base classes.",
+        ),
+    }
+
+    options = [
+        ('required-base-class', {
+            'default' : (),
+            'type': 'csv',
+            'metavar': '<class name pairs>',
+            'help': 'Fooey'}
+        ),
+    ]
+
+    def __init__(self, linter):
+        super(RequiredBaseClassChecker, self).__init__(linter)
+        self.class_map = collections.defaultdict(set)
+
+    def open(self):
+        if self.config.required_base_class:
+            for pair in self.config.required_base_class:
+                child, parent = pair.split(":")
+                self.class_map[child].add(parent)
+
+    @utils.check_messages(MESSAGE_ID)
+    def visit_class(self, node):
+        """Check each class."""
+        if self.class_map:
+            self.add_message(self.MESSAGE_ID, args=("Foo", self.class_map['Foo']), node=node)

--- a/test/test_required_base_class.py
+++ b/test/test_required_base_class.py
@@ -1,7 +1,5 @@
 """Unit tests for required-base-classes."""
 
-import unittest
-
 import astroid
 from pylint.testutils import CheckerTestCase, Message, set_config
 
@@ -9,21 +7,63 @@ from edx_lint.pylint.required_base_class import RequiredBaseClassChecker
 
 
 class RequiredBaseClassTestCase(CheckerTestCase):
+    """Unittest tests of RequiredBaseClassChecker."""
+
     CHECKER_CLASS = RequiredBaseClassChecker
 
-    def test_something(self):
-        node = astroid.parse('''
-        class MyClass(object):
-            pass
+    def get_class_node(self, code):
+        """Parse `code`, and return the last class node.
+
+        The code should have at least one class definition.
+
+        """
+        node = astroid.parse(code)
+        class_node = None
+        for body_node in node.body:
+            if getattr(body_node, 'type', 'none') == "class":
+                class_node = body_node
+        return class_node
+
+    def test_no_messages_by_default(self):
+        node = self.get_class_node('''
+            class MyClass(object):
+                pass
         ''')
         with self.assertNoMessages():
             self.checker.visit_class(node)
 
-    @set_config(required_base_class=["Foo:Bax"])
-    def test_wut(self):
-        node = astroid.parse('''
-        class MyClass(object):
-            pass
+    @set_config(required_base_class=["BaseClass:MyMixin"])
+    def test_no_messages_if_class_not_used(self):
+        node = self.get_class_node('''
+            class MyClass(object):
+                pass
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_class(node)
+
+    @set_config(required_base_class=["unittest.case.TestCase:.MyTestMixin"])
+    def test_error_if_class_is_not_used(self):
+        node = self.get_class_node('''
+            from unittest import TestCase
+            class MyClass(TestCase):
+                pass
+        ''')
+        expected_msg = Message(
+            'missing-required-base-class',
+            node=node,
+            args=('MyClass', '.MyTestMixin'),
+        )
+        with self.assertAddsMessages(expected_msg):
+            self.checker.visit_class(node)
+
+    @set_config(required_base_class=["unittest.case.TestCase:.MyTestMixin"])
+    def test_no_messages_if_class_is_used(self):
+        node = self.get_class_node('''
+            from unittest import TestCase
+            class MyTestMixin(object):
+                pass
+            class MyClass(MyTestMixin, TestCase):
+                pass
         ''')
         with self.assertNoMessages():
             self.checker.visit_class(node)

--- a/test/test_required_base_class.py
+++ b/test/test_required_base_class.py
@@ -67,3 +67,14 @@ class RequiredBaseClassTestCase(CheckerTestCase):
         ''')
         with self.assertNoMessages():
             self.checker.visit_class(node)
+
+    @set_config(required_base_class=["unittest.case.TestCase:.MyTestMixin"])
+    def test_old_style_classes(self):
+        # We don't support base class checking on old-style classes, but we
+        # have to be sure not to fall over at least.
+        node = self.get_class_node('''
+            class MyClass:
+                pass
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_class(node)

--- a/test/test_required_base_class.py
+++ b/test/test_required_base_class.py
@@ -1,0 +1,29 @@
+"""Unit tests for required-base-classes."""
+
+import unittest
+
+import astroid
+from pylint.testutils import CheckerTestCase, Message, set_config
+
+from edx_lint.pylint.required_base_class import RequiredBaseClassChecker
+
+
+class RequiredBaseClassTestCase(CheckerTestCase):
+    CHECKER_CLASS = RequiredBaseClassChecker
+
+    def test_something(self):
+        node = astroid.parse('''
+        class MyClass(object):
+            pass
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_class(node)
+
+    @set_config(required_base_class=["Foo:Bax"])
+    def test_wut(self):
+        node = astroid.parse('''
+        class MyClass(object):
+            pass
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_class(node)


### PR DESCRIPTION
This adds a new checker, for required base classes.  A new setting, `required-base-class`, is a list of colon-separated pairs:
```
required-base-class: unittest.case.TestCase:common.tests.helpers.TestMixin, ....
```
This says that if a class derives from TestCase, then it must also derive from TestMixin.  The names must be fully qualified class names.  This is unfortunate in some cases, since like with unittest.case.TestCase, the fully qualified name does not correspond to how it was imported.