### PR TITLE
Bump pylint to 1.6.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 
 setup(
     name='edx-lint',
-    version='0.5.2',
+    version='0.5.3',
     description='edX-authored pylint checkers',
     url='https://github.com/edx/edx-lint',
     author='edX',
@@ -51,7 +51,7 @@ setup(
     },
 
     install_requires=[
-        'pylint==1.6.4',
+        'pylint==1.6.5',
         'pylint-django>=0.7.2,<1.0.0',
         'pylint-celery==0.3',
         'six>=1.10.0,<2.0.0',


### PR DESCRIPTION
It was released few days ago.
Also, I've had an issue with 1.6.4 incorrectly setting exit status to 0, while it should've actually been non-zero. So there may be some false-positives.