### PR TITLE
Switch the name of the description field so that the long_description…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = edx-lint
-description = edX-authored pylint checkers
+summary = edX-authored pylint checkers
+description_file = README.rst
 url = https://github.com/edx/edx-lint
 author = edX
 author_email = oscm@edx.org


### PR DESCRIPTION
… is pulled from README.rst