### PR TITLE
pin pylint-django-version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pylint==1.7.1
 astroid==1.5.2
-pylint-django>=0.7.2,<1.0.0
+pylint-django==0.7.2
 pylint-celery==0.3
 six>=1.10.0,<2.0.0
 click>=6.0


### PR DESCRIPTION
We previously pinned pylint-django from 0.7.2 to 1.0.0. However, 0.8 has created dependency issues in repos that consume edx-lint. Since 0.7.2 is the only release prior to 0.8, I am explicitly pinning it until we have another solution.