### PR TITLE
Switch to pytest

### DIFF
--- a/edx_lint/cmd/write.py
+++ b/edx_lint/cmd/write.py
@@ -106,7 +106,10 @@ def write_main(argv):
     # pkg_resources always reads binary data (in both python2 and python3).
     # ConfigParser.read_string only exists in python3, so we have to wrap the string
     # from pkg_resources in a cStringIO so that we can pass it into ConfigParser.readfp.
-    cfg.readfp(cStringIO(resource_string), resource_name)
+    if six.PY2:
+        cfg.readfp(cStringIO(resource_string), resource_name)
+    else:
+        cfg.read_string(resource_string, resource_name)     # pylint: disable=no-member
 
     if os.path.exists(tweaks_name):
         print("Applying local tweaks from %s" % tweaks_name)

--- a/test/test_plugin_range_check.py
+++ b/test/test_plugin_range_check.py
@@ -1,18 +1,17 @@
 """Test range_check.py"""
 
 import astroid
-import ddt
-from pylint.testutils import Message
+from pylint.testutils import CheckerTestCase, Message
+import pytest
 
 from edx_lint.pylint.range_check import RangeChecker
-from .utils import PluginUnittestTestCase, get_module
+from .utils import get_module
 
 
-@ddt.ddt
-class RangeCheckerTest(PluginUnittestTestCase):
+class TestRangeCheckerTest(CheckerTestCase):
     CHECKER_CLASS = RangeChecker
 
-    @ddt.data("range", "xrange")
+    @pytest.mark.parametrize("range_name", ["range", "xrange"])
     def test_range(self, range_name):
         bad_nodes = astroid.extract_node("""
             START, STOP, STEP = 0, 10, 1

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,17 +1,7 @@
 """Testing support for pylint plugins."""
 
-import unittest
-
 import astroid.nodes
-from pylint.testutils import CheckerTestCase
 
-
-class PluginUnittestTestCase(CheckerTestCase, unittest.TestCase):
-    def setUp(self):
-        super(PluginUnittestTestCase, self).setUp()
-        # CheckerTestCase is written for pytest, so we need to bridge over to
-        # its setup method.
-        self.setup_method()
 
 def get_module(node):
     """Find the Module node from a child node."""

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist = py{27,35},coverage,pylint
 [testenv]
 deps =
     coverage
-    ddt
+    pytest
 
 commands =
-    coverage run -p -m unittest {posargs:discover -b}
+    coverage run -p -m pytest {posargs:}
 
 [testenv:coverage]
 commands =
@@ -19,9 +19,25 @@ commands =
 passenv = PYLINT*
 deps =
     Django>=1.8,<1.9
-    ddt
+    pytest
 commands = pylint edx_lint test setup.py
 
 [tox:travis]
 2.7 = py27, coverage
 3.5 = py35
+
+[pytest]
+addopts = -rfe
+
+; Warnings that we don't want to see.
+; Why we use filterwarnings instead of PYTHONWARNINGS:
+;   https://nedbatchelder.com/blog/201810/why_warnings_is_mysterious.html
+filterwarnings =
+    ; .tox/py27/lib/python2.7/site-packages/backports/configparser/__init__.py:1245:
+    ;    DeprecationWarning: You passed a bytestring. Implicitly decoding as UTF-8 string.
+    ;    This will not work on Python 3. Please switch to using Unicode strings across the board.
+    ignore:::backports
+    ; and a bunch of these... pytest is warning about its own deprecations?
+    ;   .tox/py27/lib/python2.7/site-packages/_pytest/compat.py:329:
+    ;       RemovedInPytest4Warning: usage of Session.Class is deprecated, please use pytest.Class instead
+    ignore::pytest.PytestDeprecationWarning


### PR DESCRIPTION
Switching was easy.  Quieting the warnings was a journey through multiple levels of confusion, finally culminating in a blog post (linked from the tox.ini).
