### PR TITLE
Allow for hyphenated strings in the getattr check

### DIFF
--- a/edx_lint/pylint/getattr_check.py
+++ b/edx_lint/pylint/getattr_check.py
@@ -27,6 +27,7 @@ class GetSetAttrLiteralChecker(BaseChecker):
 
     OK:
         x = getattr(obj, "attr_name", default_value)
+        x = getattr(obj, "foo-bar")
 
     The message id is literal-used-as-attribute.
 
@@ -63,8 +64,8 @@ class GetSetAttrLiteralChecker(BaseChecker):
 
         second = node.args[1]
         if isinstance(second, astroid.Const):
-            if isinstance(second.value, six.string_types):
-                # The second argument is a constant string! Bad!
+            if isinstance(second.value, six.string_types) and "-" not in second.value:
+                # The second argument is a non-hyphenated constant string! Bad!
                 self.add_message(self.MESSAGE_ID, args=node.func.name, node=node)
 
         # All is well.

--- a/test/plugins/test_getattr_check.py
+++ b/test/plugins/test_getattr_check.py
@@ -24,6 +24,9 @@ class TestGetSetAttrLiteralChecker(CheckerTestCase):
 
             # We don't get confused by another function nname
             foobar(name, "hello")
+
+            # Allow hyphenated strings to support our rest-api client which maps these to URLs
+            getattr(name, "foo-bar")
         """)
         module = get_module(bad_nodes[0])
 


### PR DESCRIPTION
Our rest-api-client is based on slumber, which uses attributes on the api-client to build URL strings. URL paths often contain hyphenated strings so we allow getattr in this case to access these properties.