### PR TITLE
Add more to the standard .editorconfig, and write our own

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -58,11 +58,26 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+max_line_length = 120
+trim_trailing_whitespace = true
 
 [{Makefile, *.mk}]
 indent_style = tab
+indent_size = 8
 
-[{*.yml, *.yaml, *.json}]
+[*.{yml,yaml,json}]
 indent_size = 2
 
-# e2776282f95423f221b17c09c4888883be77b437
+[*.js]
+indent_size = 2
+
+[*.diff]
+trim_trailing_whitespace = false
+
+[.git/*]
+trim_trailing_whitespace = false
+
+[*.rst]
+max_line_length = 79
+
+# a699cc442902ab24adc720ac080c00e9ee72f728

--- a/edx_lint/files/.editorconfig
+++ b/edx_lint/files/.editorconfig
@@ -1,18 +1,33 @@
 # This is a file to standardize editor settings: http://EditorConfig.org
 
 # Unix-style newlines with a newline ending every file
-# Set default charset
 [*]
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+max_line_length = 120
+trim_trailing_whitespace = true
 
-# Tab indentation (no size specified)
 [{Makefile, *.mk}]
+# Makefiles need tabs
 indent_style = tab
+indent_size = 8
 
-# Matches the exact files either package.json or .travis.yml
-[{*.yml, *.yaml, *.json}]
+[*.{yml,yaml,json}]
 indent_size = 2
+
+[*.js]
+indent_size = 2
+
+[*.diff]
+# Git patches need whitespace in first column for empty lines.
+trim_trailing_whitespace = false
+
+[.git/*]
+# Don't fiddle with .git files at all.
+trim_trailing_whitespace = false
+
+[*.rst]
+max_line_length = 79


### PR DESCRIPTION
I want to get these rules into more repos.  First we need to agree on them.  Having them in edx-lint is a good way to get them into other repos.

@jmbowman @cpennington @georgebabey What do you think? Contrary opinions?