### PR TITLE
INCR-4 :updated click-log and made py37 compliant

### DIFF
--- a/edx_lint/cmd/amnesty.py
+++ b/edx_lint/cmd/amnesty.py
@@ -92,7 +92,7 @@ def fix_pylint(line, errors):
     if current:
         yield PYLINT_EXCEPTION_REGEX.sub(disable_string, line)
     else:
-        yield re.sub(r'($\s*)', disable_string + r'\1', line)
+        yield re.sub(r'($\s*)', disable_string + r'\1', line, count=1)
 
 
 @click.command()
@@ -101,7 +101,6 @@ def fix_pylint(line, errors):
     help="An input file containing pylint --output-format=parseable errors. Defaults to stdin."
 )
 @click_log.simple_verbosity_option(default=u'INFO')
-@click_log.init()
 def pylint_amnesty(pylint_output):
     """
     Add ``# pylint: disable`` clauses to add exceptions to all existing pylint errors in a codebase.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pylint==1.7.6
-astroid==1.5.3
 pylint-django==0.7.2
 pylint-celery==0.3
 six>=1.10.0,<2.0.0
 click>=6.0
-click-log==0.1.8
+click-log==0.3.2


### PR DESCRIPTION
@edx/incr-reviewers

> In your pull request, ask for a new release of edx-lint to be made once it is merged.

Initial attempt to simply update click-log in `requirements.txt` failed. 

Before changing `requirements.txt` I ran `tox` using the included `tox.ini`, I got failures for `py36-pylint{20,21}` environments and `pylint` environment. 

Current status: `tox` now passes for all but `pylint` but when I go into the `.tox` folder, activate the venv and run the pylint command it passes. I am currently baffled by this. 

when I run pytest using py37 it now passes (with Django and pytest installed)

reasons for other changes:

- pylint2.x.x requires specific versions of astroid installed based on pylint version. Later versions of astroid do not seem to have `astroid.YES`.  
- click-log >=2.0 no longer has `click_log.init`.
- in python 3.7 `re.sub` will also replace the `\n` character unless `count=1`

Of note: 
- python3.7 only works with pylint>=2.0.0


