### PR TITLE
Add a check for unsafe yaml.load() calls.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ build/
 dist/
 
 .eggs/
+
+#pyenv
+.python-version

--- a/edx_lint/pylint/plugin.py
+++ b/edx_lint/pylint/plugin.py
@@ -6,12 +6,12 @@ will register them with pylint.
 
 from edx_lint.pylint import (
     getattr_check, i18n_check, module_trace, range_check, super_check,
-    layered_test_check, right_assert_check, unicode_check,
+    layered_test_check, right_assert_check, unicode_check, yaml_load_check,
 )
 
 MODS = [
     getattr_check, i18n_check, module_trace, range_check, super_check,
-    layered_test_check, right_assert_check, unicode_check,
+    layered_test_check, right_assert_check, unicode_check, yaml_load_check,
 ]
 
 def register(linter):

--- a/edx_lint/pylint/yaml_load_check.py
+++ b/edx_lint/pylint/yaml_load_check.py
@@ -1,0 +1,51 @@
+"""
+Checks for unsafe ``yaml.load()`` calls.
+The PyYAML library has not yet released a version
+that addresses the vulnerability (listed below) in the commonly
+called ``load()`` function.
+
+Vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2017-18342
+PyYAML release plan: https://github.com/yaml/pyyaml/issues/193
+
+When a new release is published, we may be able to remove this check.
+"""
+
+from pylint.checkers import BaseChecker, utils
+from pylint.interfaces import IAstroidChecker
+
+from .common import BASE_ID, check_visitors
+
+
+def register_checkers(linter):
+    """Register checkers."""
+    linter.register_checker(YamlLoadChecker(linter))
+
+
+@check_visitors
+class YamlLoadChecker(BaseChecker):
+    """
+    Checks for unsafe ``yaml.load()`` calls.
+    """
+
+    __implements__ = (IAstroidChecker,)
+
+    name = 'yaml-load-checker'
+
+    MESSAGE_ID = 'unsafe-yaml-load'
+
+    UNSAFE_CALLS = {'yaml.load', 'yaml.load_all'}
+
+    msgs = {
+        'C{}57'.format(BASE_ID): (
+            u'yaml.load%s() call is unsafe, use yaml.safe_load%s()',
+            MESSAGE_ID,
+            'yaml.load*() is unsafe',
+        ),
+    }
+
+    @utils.check_messages(MESSAGE_ID)
+    def visit_call(self, node):
+        func_name = node.func.as_string()
+        if func_name in self.UNSAFE_CALLS:
+            suffix = func_name.lstrip('yaml.load')
+            self.add_message(self.MESSAGE_ID, args=(suffix, suffix), node=node)

--- a/test/plugins/test_unicode_check.py
+++ b/test/plugins/test_unicode_check.py
@@ -7,7 +7,6 @@ from .pylint_test import run_pylint
 
 MSG_IDS = "unicode-format-string"
 
-# pylint: disable=unicode-format-string
 
 def test_unicode_checker():
     source = """\

--- a/test/plugins/test_yaml_load_check.py
+++ b/test/plugins/test_yaml_load_check.py
@@ -1,0 +1,33 @@
+"""Test yaml_load_check.py"""
+
+from .pylint_test import run_pylint
+
+
+MSG_IDS = 'unsafe-yaml-load'
+
+
+def test_unsafe_yaml_load_warnings():
+    source = """\
+        yaml.load('foo.bar')                      #=A
+        yaml.load_all('foo.bar')                  #=B
+
+    """
+    messages = run_pylint(source, MSG_IDS)
+
+    expected_messages = {
+        'A:unsafe-yaml-load:yaml.load() call is unsafe, use yaml.safe_load()',
+        'B:unsafe-yaml-load:yaml.load_all() call is unsafe, use yaml.safe_load_all()',
+    }
+    assert expected_messages == messages
+
+
+def test_safe_yaml_invocations_are_fine():
+    source = """\
+        yaml.safe_load('this.is.fine')
+        yaml.safe_load_all('this.is.fine')
+        myaml.load('this.is.fine.too')
+        myaml.load_all('this.is.fine.too')
+
+    """
+    messages = run_pylint(source, MSG_IDS)
+    assert not messages


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2017-18342

> In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.

There's not a stable release beyond 3.13 yet (which is the version of `pyyaml` we're using), so let's go with this in the meantime?