### PR TITLE
Disable open-builtin pylint violation.

### DIFF
--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -307,6 +307,7 @@ disable=
     old-ne-operator,
     old-octal-literal,
     old-raise-syntax,
+    open-builtin,
     parameter-unpacking,
     print-statement,
     raising-string,


### PR DESCRIPTION
I don't see a good reason for this violation. It seems that `open()` is still the best practice for opening a file in Python3. If I'm incorrect, please educate me! 