### PR TITLE
Travis CI: Remove sudo tag and add Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     env: DISTRIBUTIONS="sdist bdist_wheel --universal"
   - python: "3.6"
   - python: "3.7"
-    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+    dist: latest  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
   - python: "2.7"
     env: TOXARG="-e pylint"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
   - python: "2.7"
     env: TOXARG="-e pylint"
+ allow_failures:
+  - python: "3.7"
 
 install:
     - pip install --upgrade pip setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
   - python: "2.7"
     env: DISTRIBUTIONS="sdist bdist_wheel --universal"
   - python: "3.6"
+  - python: "3.7"
+    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
   - python: "2.7"
     env: TOXARG="-e pylint"
-
-sudo: false
 
 install:
     - pip install --upgrade pip setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
   - python: "2.7"
     env: TOXARG="-e pylint"
- allow_failures:
-  - python: "3.7"
 
 install:
     - pip install --upgrade pip setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36}-pylint{17,18,19}, py36-pylint{20,21}, coverage, pylint
+envlist = py{27,36,37}-pylint{17,18,19}, py{36,37}-pylint{20,21}, coverage, pylint
 
 [testenv]
 deps =
@@ -33,6 +33,7 @@ commands = pylint edx_lint test setup.py
 [tox:travis]
 2.7 = py27-pylint17, coverage
 3.6 = py36-pylint17
+3.7 = py37-pylint17
 
 [pytest]
 addopts = -rfe

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands = pylint edx_lint test setup.py
 [tox:travis]
 2.7 = py27-pylint17, coverage
 3.6 = py36-pylint17
-3.7 = py37-pylint17
+3.7 = py37-pylint18  # StopIteration fix added
 
 [pytest]
 addopts = -rfe

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36,37}-pylint{17,18,19}, py{36,37}-pylint{20,21}, coverage, pylint
+envlist = py{27,36,37}-pylint{17,18,19}, py{36,37}-pylint{20,21,22}, coverage, pylint
 
 [testenv]
 deps =
@@ -15,6 +15,7 @@ commands =
     pylint19: pip install -q pylint>=1.9,<2.0
     pylint20: pip install -q pylint>=2.0,<2.1
     pylint21: pip install -q pylint>=2.1,<2.2
+    pylint22: pip install -q pylint>=2.2,<2.3
     pylint --version
     coverage run -p -m pytest {posargs:}
 
@@ -33,7 +34,7 @@ commands = pylint edx_lint test setup.py
 [tox:travis]
 2.7 = py27-pylint17, coverage
 3.6 = py36-pylint17
-3.7 = py37-pylint19  # StopIteration fix added
+3.7 = py37-pylint20
 
 [pytest]
 addopts = -rfe

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands = pylint edx_lint test setup.py
 [tox:travis]
 2.7 = py27-pylint17, coverage
 3.6 = py36-pylint17
-3.7 = py37-pylint18  # StopIteration fix added
+3.7 = py37-pylint19  # StopIteration fix added
 
 [pytest]
 addopts = -rfe


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

pylint 2.x is required to support Python 3.7:
* http://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-0