### PR TITLE
Don't test py37-pylint1x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36,37}-pylint{17,18,19}, py{36,37}-pylint{20,21,22}, coverage, pylint
+envlist = py{27,36}-pylint{17,18,19}, py{36,37}-pylint{20,21,22}, coverage, pylint
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.7 fails when running Pylint 1.x.  We don't need it to work, so don't test it.