### PR TITLE
tox.ini: Legacy pylint raises StopIteration in Python 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36,37}-pylint{17,18,19}, py{36,37}-pylint{20,21,22}, coverage, pylint
+envlist = py{27,36}-pylint{17,18,19}, py{36,37}-pylint{20,21,22}, coverage, pylint
 
 [testenv]
 deps =


### PR DESCRIPTION
As discussed at https://github.com/edx/edx-lint/pull/93#issuecomment-467115234