### PR TITLE
add ungrouped-imports to disabled rule

### DIFF
--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -326,6 +326,7 @@ disable=
     too-many-locals,
     too-many-public-methods,
     too-many-return-statements,
+    ungrouped-imports,
     unichr-builtin,
     unicode-builtin,
     unpacking-in-except,

--- a/pylintrc
+++ b/pylintrc
@@ -26,23 +26,28 @@
 # 1. Edit the pylintrc file in the edx-lint repo at
 #    https://github.com/edx/edx-lint/blob/master/edx_lint/files/pylintrc
 #
-# 2. Run (in edx-lint repo):
+# 2. install the updated version of edx-lint (in edx-lint):
+#
+#       $ pip install .
+#
+# 3. Run (in edx-lint):
 #
 #       # uses pylintrc_tweaks from edx-lint for linting in edx-lint
+#       # NOTE: Use Python 3.x, which no longer includes comments in the output file
 #       $ edx_lint write pylintrc
-
-# 3. Make a new version of edx_lint, submit and review a pull request with the
+#
+# 4. Make a new version of edx_lint, submit and review a pull request with the
 #    pylintrc update, and after merging, update the edx-lint version by
 #    creating a new tag in the repo (uses pbr).
 #
-# 4. In your local repo, install the newer version of edx-lint.
+# 5. In your local repo, install the newer version of edx-lint.
 #
-# 5. Run:
+# 6. Run:
 #
 #       # uses local pylintrc_tweaks
 #       $ edx_lint write pylintrc
 #
-# 6. This will modify the local file.  Submit a pull request to get it
+# 7. This will modify the local file.  Submit a pull request to get it
 #    checked in so that others will benefit.
 #
 #
@@ -340,6 +345,7 @@ disable =
 	too-many-locals,
 	too-many-public-methods,
 	too-many-return-statements,
+	ungrouped-imports,
 	unichr-builtin,
 	unicode-builtin,
 	unpacking-in-except,
@@ -445,4 +451,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 7edd7f25600478750157d7b451c8c303ad1294db
+# d0f4059e1f1707d621743c27369d6d4d0d727696


### PR DESCRIPTION
Turns out that removing this rule from enabled in earlier commit
wasn't good enough.