### PR TITLE
No need for numeric scores on pylint

### DIFF
--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -337,7 +337,6 @@ disable=
     zip-builtin-not-iterating,
 
 
-
 [REPORTS]
 
 # Set the output format. Available formats are text, parseable, colorized, msvs
@@ -353,13 +352,8 @@ files-output=no
 # Tells whether to display a full report or only the messages
 reports=no
 
-# Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables errors warning, statement which
-# respectively contain the number of errors / warnings messages and the total
-# number of statements analyzed. This is used by the global evaluation report
-# (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
+# Numeric scores are silly.
+score=no
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details

--- a/pylintrc
+++ b/pylintrc
@@ -359,7 +359,7 @@ disable =
 output-format = text
 files-output = no
 reports = no
-evaluation = 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+score = no
 
 [BASIC]
 bad-functions = map,filter,apply,input
@@ -453,4 +453,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 2d0f98bd8d73d1e1c10330c897d9d213d06f0d5d
+# d70c10b1a41a0b8d5215ea58c7e5be7e62b03d1e


### PR DESCRIPTION
The numeric score is meaningless and unactionable.

Also: pylint writes score output even if there are no violations.  I prefer the clean no-output look when everything passes.  Do some people like seeing the 10.00 score when everything is good?