### PR TITLE
 ARCHBOM-1305: remove flag_undefined_default

### DIFF
--- a/test/plugins/test_feature_toggle_check.py
+++ b/test/plugins/test_feature_toggle_check.py
@@ -31,7 +31,6 @@ def test_waffle_missing_toggle_annotation_check():
         MissingCourseWithKwarg = CourseWaffleFlag( #=F
             waffle_namespace=waffle_flags(),
             flag_name=u'missing_course_with_kwarg',
-            flag_undefined_default=False
         )
         """
 


### PR DESCRIPTION
flag_undefined_default has been deprecated and
is being removed, so remove it from the test.

ARCHBOM-1305