### PR TITLE
Adding common constraint file for edx repos usage.

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -1,0 +1,3 @@
+# common constraints file across edx usage
+# using LTS django version
+Django<2.3

--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -1,3 +1,12 @@
-# common constraints file across edx usage
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.  
+# Writing an issue against the offending project and linking to it here is good.
+
 # using LTS django version
 Django<2.3


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1867

Purpose of this file is to define a common constraint at one place and use it in all edx repos. e.g right now all edx repos using `django<2.3` but we have to mentioned it in all repos local constraint.txt file. But now you can just define the constraint in this file and call the path in ur desired edx repo constraint.txt like this 

`-c https://raw.githubusercontent.com/edx/edx-lint/84f463efed7f287a60eeb44cffa4884342066b2c/edx_lint/files/common_constraints.txt`

If you don't need the constraint version you can overwrite in local constraint file.