### PR TITLE
pytest-xdist latest version breaking tests. It needs to pin

### DIFF
--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-VERSION = "1.5.2"
+VERSION = "1.5.3"

--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -10,3 +10,7 @@
 
 # using LTS django version
 Django<2.3
+
+
+# pytest-xdist>=2.0.0 removes some aliases and until pytest-django>=3.10.0 is released, this will break tests.
+pytest-xdist==1.34.0


### PR DESCRIPTION

pytest-xdist latest version breaking tests. It needs to pin in all repos.