### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,5 +99,5 @@ The Open edX project has resources for developer support on the `Getting Help`_ 
 
 .. _Getting Help: https://open.edx.org/getting-help
 
-.. |Travis| image:: https://travis-ci.org/edx/edx-lint.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/edx-lint
+.. |Travis| image:: https://travis-ci.com/edx/edx-lint.svg?branch=master
+.. _Travis: https://travis-ci.com/edx/edx-lint


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089