### PR TITLE
[BD-21] Fix line number in annotation checks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.0.2] - 2021-01-26
+~~~~~~~~~~~~~~~~~~~~
+
+* Fix line number from annotation checks.
+
 [3.0.1] - 2021-01-26
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-VERSION = "3.0.1"
+VERSION = "3.0.2"

--- a/edx_lint/pylint/annotations_check.py
+++ b/edx_lint/pylint/annotations_check.py
@@ -323,7 +323,10 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
         toggle_name = ""
         toggle_description = ""
         toggle_default = None
+        line_number = None
         for annotation in annotations:
+            if line_number is None:
+                line_number = annotation["line_number"]
             if annotation["annotation_token"] == ".. toggle_name:":
                 toggle_name = annotation["annotation_data"]
             elif annotation["annotation_token"] == ".. toggle_description:":
@@ -340,24 +343,28 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
             self.add_message(
                 self.NO_NAME_MESSAGE_ID,
                 node=node,
+                line=line_number,
             )
         if not toggle_description:
             self.add_message(
                 self.EMPTY_DESCRIPTION_MESSAGE_ID,
                 args=(toggle_name,),
                 node=node,
+                line=line_number,
             )
         if temporary_use_case and not target_removal_date:
             self.add_message(
                 self.MISSING_TARGET_REMOVAL_DATE_MESSAGE_ID,
                 args=(toggle_name,),
                 node=node,
+                line=line_number,
             )
         if toggle_default not in ["True", "False"]:
             self.add_message(
                 self.NON_BOOLEAN_DEFAULT_VALUE,
                 args=(toggle_name,),
                 node=node,
+                line=line_number,
             )
 
 
@@ -399,7 +406,10 @@ class SettingAnnotationChecker(AnnotationBaseChecker):
 
         setting_name = ""
         setting_default = None
+        line_number = None
         for annotation in annotations:
+            if line_number is None:
+                line_number = annotation["line_number"]
             if annotation["annotation_token"] == ".. setting_name:":
                 setting_name = annotation["annotation_data"]
             elif annotation["annotation_token"] == ".. setting_default:":
@@ -410,4 +420,5 @@ class SettingAnnotationChecker(AnnotationBaseChecker):
                 self.BOOLEAN_DEFAULT_VALUE,
                 args=(setting_name,),
                 node=node,
+                line=line_number,
             )

--- a/test/plugins/test_annotations_check.py
+++ b/test/plugins/test_annotations_check.py
@@ -150,7 +150,7 @@ def test_temporary_use_case_without_target_removal_date():
     """
     messages = run_pylint(source, "toggle-missing-target-removal-date")
     expected = {
-        "1:toggle-missing-target-removal-date:temporary feature toggle (MYTOGGLE) has no target removal date"
+        "2:toggle-missing-target-removal-date:temporary feature toggle (MYTOGGLE) has no target removal date"
     }
     assert expected == messages
 
@@ -170,7 +170,7 @@ def test_toggle_with_empty_name():
     """
     messages = run_pylint(source, "toggle-no-name")
     expected = {
-        "1:toggle-no-name:feature toggle has no name"
+        "2:toggle-no-name:feature toggle has no name"
     }
     assert expected == messages
 
@@ -182,7 +182,7 @@ def test_toggle_with_empty_description():
     """
     messages = run_pylint(source, "toggle-empty-description")
     expected = {
-        "1:toggle-empty-description:feature toggle (MYTOGGLE) does not have a description"
+        "2:toggle-empty-description:feature toggle (MYTOGGLE) does not have a description"
     }
     assert expected == messages
 
@@ -194,7 +194,7 @@ def test_non_boolean_default_value():
     """
     messages = run_pylint(source, "toggle-non-boolean-default-value")
     expected = {
-        "1:toggle-non-boolean-default-value:feature toggle (MYTOGGLE) default value must be boolean ('True' or 'False')"
+        "2:toggle-non-boolean-default-value:feature toggle (MYTOGGLE) default value must be boolean ('True' or 'False')"
     }
     assert expected == messages
 
@@ -206,6 +206,6 @@ def test_setting_boolean_default_value():
     """
     messages = run_pylint(source, "setting-boolean-default-value")
     expected = {
-        "1:setting-boolean-default-value:setting annotation (MYSETTING) cannot have a boolean value"
+        "2:setting-boolean-default-value:setting annotation (MYSETTING) cannot have a boolean value"
     }
     assert expected == messages


### PR DESCRIPTION
Annotation checks did not define a line number, which caused all annotation
failures to be associated with line 1. This caused CI not to fail, despite some
linting issues. We resolve this by associating the annotation group line number
to the linting errors.

cc @robrap 

This should be ready to review.