### PR TITLE
Pinned social-auth-core to resolve make upgrade conflicts

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -12,4 +12,5 @@
 Django<2.3
 
 # Pinned social-auth-core to <4.0.3 untill drf-jwt adds support for PyJWT>2.0
+# https://github.com/Styria-Digital/django-rest-framework-jwt/issues/76 
 social-auth-core<4.0.3

--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -10,3 +10,6 @@
 
 # using LTS django version
 Django<2.3
+
+# Pinned social-auth-core to <4.0.3 untill drf-jwt adds support for PyJWT>2.0
+social-auth-core<4.0.3


### PR DESCRIPTION
This needs to be pinned to resolve make upgrade conflicts in most of the services.

`drf-jwt` has pinned `PyJWT`: https://github.com/Styria-Digital/django-rest-framework-jwt/blob/612ba1e5f300477334c49c0fddaaac82b80f587a/setup.cfg#L39