### PR TITLE
Switch constraints to constraints.txt file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.0.1] - 2021-01-26
+~~~~~~~~~~~~~~~~~~~~
+
+* Added constraints file to handle package versions.
 
 [3.0.0] - 2021-01-24
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-VERSION = "3.0"
+VERSION = "3.0.1"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,9 +1,10 @@
-code-annotations>=1.0.1    # Parse feature toggle and setting annotations
-Django>=2.2,<2.3           # Version coherent with other projects
-# Note that these requirements are pinned in order to provide a pinned pylint version for all dependent projects.
-pylint==2.6.0
-pylint-django==2.3.0
-pylint-celery==0.3
-six>=1.10.0,<2.0.0
-click>=6.0
-click-log==0.3.2
+-c constraints.txt
+
+code-annotations
+click
+click-log
+Django
+pylint
+pylint-django
+pylint-celery
+six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,27 +4,78 @@
 #
 #    make upgrade
 #
-astroid==2.4.2            # via pylint, pylint-celery
-click-log==0.3.2          # via -r requirements/base.in
-click==7.1.2              # via -r requirements/base.in, click-log, code-annotations
-code-annotations==1.0.1   # via -r requirements/base.in
-django==2.2.17            # via -r requirements/base.in, code-annotations
-isort==5.7.0              # via pylint
-jinja2==2.11.2            # via code-annotations
-lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via pylint
-pbr==5.5.1                # via stevedore
-pylint-celery==0.3        # via -r requirements/base.in
-pylint-django==2.3.0      # via -r requirements/base.in
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.6.0             # via -r requirements/base.in, pylint-celery, pylint-django, pylint-plugin-utils
-python-slugify==4.0.1     # via code-annotations
-pytz==2020.5              # via django
-pyyaml==5.3.1             # via code-annotations
-six==1.15.0               # via -r requirements/base.in, astroid
-sqlparse==0.4.1           # via django
-stevedore==3.3.0          # via code-annotations
-text-unidecode==1.3       # via python-slugify
-toml==0.10.2              # via pylint
-wrapt==1.12.1             # via astroid
+astroid==2.4.2
+    # via
+    #   pylint
+    #   pylint-celery
+click-log==0.3.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+click==7.1.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   click-log
+    #   code-annotations
+code-annotations==1.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+django==2.2.17
+    # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
+    #   -r requirements/base.in
+    #   code-annotations
+isort==5.7.0
+    # via pylint
+jinja2==2.11.2
+    # via code-annotations
+lazy-object-proxy==1.4.3
+    # via astroid
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via pylint
+pbr==5.5.1
+    # via stevedore
+pylint-celery==0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+pylint-django==2.3.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+pylint-plugin-utils==0.6
+    # via
+    #   pylint-celery
+    #   pylint-django
+pylint==2.6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
+python-slugify==4.0.1
+    # via code-annotations
+pytz==2020.5
+    # via django
+pyyaml==5.4.1
+    # via code-annotations
+six==1.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   astroid
+sqlparse==0.4.1
+    # via django
+stevedore==3.3.0
+    # via code-annotations
+text-unidecode==1.3
+    # via python-slugify
+toml==0.10.2
+    # via pylint
+wrapt==1.12.1
+    # via astroid

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,1 +1,3 @@
+-c constraints.txt
+
 tox

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,14 +4,30 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
-packaging==20.8           # via tox
-pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
-pyparsing==2.4.7          # via packaging
-six==1.15.0               # via tox, virtualenv
-toml==0.10.2              # via tox
-tox==3.21.0               # via -r requirements/ci.in
-virtualenv==20.3.0        # via tox
+appdirs==1.4.4
+    # via virtualenv
+distlib==0.3.1
+    # via virtualenv
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+packaging==20.8
+    # via tox
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pyparsing==2.4.7
+    # via packaging
+six==1.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via tox
+tox==3.21.2
+    # via -r requirements/ci.in
+virtualenv==20.4.0
+    # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,11 @@
+# Common constraints for edx repos
+-c ../edx_lint/files/common_constraints.txt
+
+code-annotations>=1.0.1
+# Note that these requirements are pinned in order to provide a pinned pylint version for all dependent projects.
+pylint==2.6.0
+pylint-django==2.3.0
+pylint-celery==0.3
+six>=1.10.0,<2.0.0
+click>=6.0
+click-log==0.3.2

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,4 @@
+-c constraints.txt
 -r base.txt
 
 tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,37 +4,135 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-astroid==2.4.2            # via -r requirements/base.txt, pylint, pylint-celery
-click-log==0.3.2          # via -r requirements/base.txt
-click==7.1.2              # via -r requirements/base.txt, click-log, code-annotations
-code-annotations==1.0.1   # via -r requirements/base.txt
-distlib==0.3.1            # via virtualenv
-django==2.2.17            # via -r requirements/base.txt, code-annotations
-filelock==3.0.12          # via tox, virtualenv
-isort==5.7.0              # via -r requirements/base.txt, pylint
-jinja2==2.11.2            # via -r requirements/base.txt, code-annotations
-lazy-object-proxy==1.4.3  # via -r requirements/base.txt, astroid
-markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mccabe==0.6.1             # via -r requirements/base.txt, pylint
-packaging==20.8           # via tox
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
-pylint-celery==0.3        # via -r requirements/base.txt
-pylint-django==2.3.0      # via -r requirements/base.txt
-pylint-plugin-utils==0.6  # via -r requirements/base.txt, pylint-celery, pylint-django
-pylint==2.6.0             # via -r requirements/base.txt, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.7          # via packaging
-python-slugify==4.0.1     # via -r requirements/base.txt, code-annotations
-pytz==2020.5              # via -r requirements/base.txt, django
-pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations
-six==1.15.0               # via -r requirements/base.txt, astroid, tox, virtualenv
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==3.3.0          # via -r requirements/base.txt, code-annotations
-text-unidecode==1.3       # via -r requirements/base.txt, python-slugify
-toml==0.10.2              # via -r requirements/base.txt, pylint, tox
-tox-battery==0.6.1        # via -r requirements/dev.in
-tox==3.21.0               # via -r requirements/dev.in, tox-battery
-virtualenv==20.3.0        # via tox
-wrapt==1.12.1             # via -r requirements/base.txt, astroid
+appdirs==1.4.4
+    # via virtualenv
+astroid==2.4.2
+    # via
+    #   -r requirements/base.txt
+    #   pylint
+    #   pylint-celery
+click-log==0.3.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+click==7.1.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   click-log
+    #   code-annotations
+code-annotations==1.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+distlib==0.3.1
+    # via virtualenv
+django==2.2.17
+    # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
+    #   -r requirements/base.txt
+    #   code-annotations
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+isort==5.7.0
+    # via
+    #   -r requirements/base.txt
+    #   pylint
+jinja2==2.11.2
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+lazy-object-proxy==1.4.3
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+markupsafe==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
+mccabe==0.6.1
+    # via
+    #   -r requirements/base.txt
+    #   pylint
+packaging==20.8
+    # via tox
+pbr==5.5.1
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pylint-celery==0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+pylint-django==2.3.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+pylint-plugin-utils==0.6
+    # via
+    #   -r requirements/base.txt
+    #   pylint-celery
+    #   pylint-django
+pylint==2.6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
+pyparsing==2.4.7
+    # via packaging
+python-slugify==4.0.1
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+pytz==2020.5
+    # via
+    #   -r requirements/base.txt
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+six==1.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   astroid
+    #   tox
+    #   virtualenv
+sqlparse==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+stevedore==3.3.0
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+text-unidecode==1.3
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
+toml==0.10.2
+    # via
+    #   -r requirements/base.txt
+    #   pylint
+    #   tox
+tox-battery==0.6.1
+    # via -r requirements/dev.in
+tox==3.21.2
+    # via
+    #   -r requirements/dev.in
+    #   tox-battery
+virtualenv==20.4.0
+    # via tox
+wrapt==1.12.1
+    # via
+    #   -r requirements/base.txt
+    #   astroid

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,10 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -r requirements/pip-tools.in
+click==7.1.2
+    # via pip-tools
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,8 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.35.1             # via -r requirements/pip.in
+wheel==0.35.1
+    # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.4               # via -r requirements/pip.in
-setuptools==50.3.2        # via -r requirements/pip.in
+pip==20.2.4
+    # via -r requirements/pip.in
+setuptools==50.3.2
+    # via -r requirements/pip.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,6 @@
+-c constraints.txt
 -r dev.txt
 
 coverage
-Django>=2.2,<2.3
+Django
 pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,41 +4,163 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via -r requirements/dev.txt, virtualenv
-astroid==2.4.2            # via -r requirements/dev.txt, pylint, pylint-celery
-attrs==20.3.0             # via pytest
-click-log==0.3.2          # via -r requirements/dev.txt
-click==7.1.2              # via -r requirements/dev.txt, click-log, code-annotations
-code-annotations==1.0.1   # via -r requirements/dev.txt
-coverage==5.3.1           # via -r requirements/test.in
-distlib==0.3.1            # via -r requirements/dev.txt, virtualenv
-django==2.2.17            # via -r requirements/dev.txt, -r requirements/test.in, code-annotations
-filelock==3.0.12          # via -r requirements/dev.txt, tox, virtualenv
-iniconfig==1.1.1          # via pytest
-isort==5.7.0              # via -r requirements/dev.txt, pylint
-jinja2==2.11.2            # via -r requirements/dev.txt, code-annotations
-lazy-object-proxy==1.4.3  # via -r requirements/dev.txt, astroid
-markupsafe==1.1.1         # via -r requirements/dev.txt, jinja2
-mccabe==0.6.1             # via -r requirements/dev.txt, pylint
-packaging==20.8           # via -r requirements/dev.txt, pytest, tox
-pbr==5.5.1                # via -r requirements/dev.txt, stevedore
-pluggy==0.13.1            # via -r requirements/dev.txt, pytest, tox
-py==1.10.0                # via -r requirements/dev.txt, pytest, tox
-pylint-celery==0.3        # via -r requirements/dev.txt
-pylint-django==2.3.0      # via -r requirements/dev.txt
-pylint-plugin-utils==0.6  # via -r requirements/dev.txt, pylint-celery, pylint-django
-pylint==2.6.0             # via -r requirements/dev.txt, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.7          # via -r requirements/dev.txt, packaging
-pytest==6.2.1             # via -r requirements/test.in
-python-slugify==4.0.1     # via -r requirements/dev.txt, code-annotations
-pytz==2020.5              # via -r requirements/dev.txt, django
-pyyaml==5.3.1             # via -r requirements/dev.txt, code-annotations
-six==1.15.0               # via -r requirements/dev.txt, astroid, tox, virtualenv
-sqlparse==0.4.1           # via -r requirements/dev.txt, django
-stevedore==3.3.0          # via -r requirements/dev.txt, code-annotations
-text-unidecode==1.3       # via -r requirements/dev.txt, python-slugify
-toml==0.10.2              # via -r requirements/dev.txt, pylint, pytest, tox
-tox-battery==0.6.1        # via -r requirements/dev.txt
-tox==3.21.0               # via -r requirements/dev.txt, tox-battery
-virtualenv==20.3.0        # via -r requirements/dev.txt, tox
-wrapt==1.12.1             # via -r requirements/dev.txt, astroid
+appdirs==1.4.4
+    # via
+    #   -r requirements/dev.txt
+    #   virtualenv
+astroid==2.4.2
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
+    #   pylint-celery
+attrs==20.3.0
+    # via pytest
+click-log==0.3.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.txt
+click==7.1.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.txt
+    #   click-log
+    #   code-annotations
+code-annotations==1.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.txt
+coverage==5.3.1
+    # via -r requirements/test.in
+distlib==0.3.1
+    # via
+    #   -r requirements/dev.txt
+    #   virtualenv
+django==2.2.17
+    # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
+    #   -r requirements/dev.txt
+    #   -r requirements/test.in
+    #   code-annotations
+filelock==3.0.12
+    # via
+    #   -r requirements/dev.txt
+    #   tox
+    #   virtualenv
+iniconfig==1.1.1
+    # via pytest
+isort==5.7.0
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
+jinja2==2.11.2
+    # via
+    #   -r requirements/dev.txt
+    #   code-annotations
+lazy-object-proxy==1.4.3
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
+markupsafe==1.1.1
+    # via
+    #   -r requirements/dev.txt
+    #   jinja2
+mccabe==0.6.1
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
+packaging==20.8
+    # via
+    #   -r requirements/dev.txt
+    #   pytest
+    #   tox
+pbr==5.5.1
+    # via
+    #   -r requirements/dev.txt
+    #   stevedore
+pluggy==0.13.1
+    # via
+    #   -r requirements/dev.txt
+    #   pytest
+    #   tox
+py==1.10.0
+    # via
+    #   -r requirements/dev.txt
+    #   pytest
+    #   tox
+pylint-celery==0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.txt
+pylint-django==2.3.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.txt
+pylint-plugin-utils==0.6
+    # via
+    #   -r requirements/dev.txt
+    #   pylint-celery
+    #   pylint-django
+pylint==2.6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.txt
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
+pyparsing==2.4.7
+    # via
+    #   -r requirements/dev.txt
+    #   packaging
+pytest==6.2.2
+    # via -r requirements/test.in
+python-slugify==4.0.1
+    # via
+    #   -r requirements/dev.txt
+    #   code-annotations
+pytz==2020.5
+    # via
+    #   -r requirements/dev.txt
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/dev.txt
+    #   code-annotations
+six==1.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.txt
+    #   astroid
+    #   tox
+    #   virtualenv
+sqlparse==0.4.1
+    # via
+    #   -r requirements/dev.txt
+    #   django
+stevedore==3.3.0
+    # via
+    #   -r requirements/dev.txt
+    #   code-annotations
+text-unidecode==1.3
+    # via
+    #   -r requirements/dev.txt
+    #   python-slugify
+toml==0.10.2
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
+    #   pytest
+    #   tox
+tox-battery==0.6.1
+    # via -r requirements/dev.txt
+tox==3.21.2
+    # via
+    #   -r requirements/dev.txt
+    #   tox-battery
+virtualenv==20.4.0
+    # via
+    #   -r requirements/dev.txt
+    #   tox
+wrapt==1.12.1
+    # via
+    #   -r requirements/dev.txt
+    #   astroid


### PR DESCRIPTION
**Issue:** [BOM-2261](https://openedx.atlassian.net/browse/BOM-2261)

### Description
- `base.in` had `Django<2.3` constraint which caused conflicts & hence [build failure](https://travis-ci.com/github/edx/edx-organizations/jobs/475385652) in Django30 & Django31 tests where this package is being used as a dependency. 
- Added `constraints.txt` file for pinning the versions which resolved the issue and [tests](https://github.com/edx/edx-organizations/pull/166) passed using this commit. 