### PR TITLE
[BD-21] Report generic code annotation errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,18 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.0.0] - 2021-01-28
+~~~~~~~~~~~~~~~~~~~~
+
+* BREAKING CHANGE: modify the numerical ID of annotation checks
+* BREAKING CHANGES:
+
+  * modify the numerical ID of annotation checks
+  * though technically not a breaking change, the new annotation checks may break your build if there are pre-existing
+    violations.
+
+* Add ``CodeAnnotationChecker`` to run generic checks on annotations
+
 [3.0.2] - 2021-01-26
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-VERSION = "3.0.2"
+VERSION = "4.0.0"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ click==7.1.2
     #   -r requirements/base.in
     #   click-log
     #   code-annotations
-code-annotations==1.0.2
+code-annotations==1.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,7 +1,7 @@
 # Common constraints for edx repos
 -c ../edx_lint/files/common_constraints.txt
 
-code-annotations>=1.0.1
+code-annotations>=1.1.0
 # Note that these requirements are pinned in order to provide a pinned pylint version for all dependent projects.
 pylint==2.6.0
 pylint-django==2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ click==7.1.2
     #   -r requirements/base.txt
     #   click-log
     #   code-annotations
-code-annotations==1.0.2
+code-annotations==1.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,7 +25,7 @@ click==7.1.2
     #   -r requirements/dev.txt
     #   click-log
     #   code-annotations
-code-annotations==1.0.2
+code-annotations==1.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt

--- a/test/plugins/test_annotations_check.py
+++ b/test/plugins/test_annotations_check.py
@@ -1,5 +1,5 @@
 """Test annotations_check.py"""
-# pylint: disable=toggle-non-boolean-default-value,toggle-empty-description,toggle-no-name
+# pylint: disable=toggle-non-boolean-default-value,toggle-empty-description,toggle-no-name,annotation-missing-token
 
 from .pylint_test import run_pylint
 
@@ -139,6 +139,18 @@ def test_illegal_waffle_usage_check():
         "use utility classes WaffleFlag, WaffleSwitch, CourseWaffleFlag.",
         "D:illegal-waffle-usage:illegal waffle usage with (TEST_FLAG): "
         "use utility classes WaffleFlag, WaffleSwitch, CourseWaffleFlag.",
+    }
+    assert expected == messages
+
+
+def test_code_annotations_checker():
+    source = """
+    # .. toggle_name: MYTOGGLE
+    # .. toggle_name: MYTOGGLE
+    """
+    messages = run_pylint(source, "annotation-duplicate-token")
+    expected = {
+        "2:annotation-duplicate-token:found duplicate token '.. toggle_name:'"
     }
     assert expected == messages
 

--- a/test/plugins/test_ignore_long_lines.py
+++ b/test/plugins/test_ignore_long_lines.py
@@ -1,7 +1,7 @@
 """
 Test ignore-long-lines regex
 """
-# pylint: disable=toggle-no-name,toggle-non-boolean-default-value
+# pylint: disable=toggle-no-name,toggle-non-boolean-default-value,annotation-missing-token
 
 from .pylint_test import run_pylint
 


### PR DESCRIPTION
Previously, it was required to run `code_annotations --lint` in order to verify
code annotations. The errors then had to be collected manually, for instance
with a paver task. This made it intractable to generalize code annotation
checking to multiple IDAs. With this new checker, code annotation errors are
sent to pylint, which makes it easy for everyone to quickly detect annotation
errors. To achieve this, we make use of the new code annotations API created in
v1.1.0.

This PR depends on https://github.com/edx/code-annotations/pull/61 (:heavy_check_mark: merged)

cc @robrap 