### PR TITLE
BOM-2341 : Don't put amnesty on line continuation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.1.1] - 2021-03-16
+~~~~~~~~~~~~~~~~~~~~
+
+* Fixed lint amnesty breakage on line continuation
+
+
 [4.1.0] - 2021-02-24
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-VERSION = "4.1.0"
+VERSION = "4.1.1"

--- a/edx_lint/cmd/amnesty.py
+++ b/edx_lint/cmd/amnesty.py
@@ -117,6 +117,11 @@ def pylint_amnesty(pylint_output):
             with opened_file as input_file:
                 output_lines = []
                 for line_num, line in enumerate(input_file, start=1):
+                    # If the line ends with backslash, take the amnesty to next line because line of code has not ended
+                    if line.endswith('\\\n'):
+                        errors[file_with_errors][line_num + 1] = errors[file_with_errors][line_num]
+                        errors[file_with_errors][line_num] = set()
+
                     output_lines.extend(fix_pylint(line, errors[file_with_errors][line_num]))
 
             with open(file_with_errors, "w") as output_file:


### PR DESCRIPTION
edx-lint amnesty breaks when it runs into line continuations because it places the comment after the backslash.

Commit for reference:
https://github.com/edx/edx-platform/pull/26391/commits/4afb7c4dfc7005125f4abb3f3440e6b035d27559#diff-9105611e27bef349fe3153c23fdb4789e8c23f1503202e03e19bf14ef70415faR224

Went from:
```
log.warning('Error in conditional module: \
required module {module} has no {module_attr}'.format(module=module, module_attr=attr_name))
```
to
```
 log.warning('Error in conditional module: \  # lint-amnesty, pylint: disable=logging-format-interpolation 
     required module {module} has no {module_attr}'.format(module=module, module_attr=attr_name))
```
which becomes a syntax error.

This PR fixes the problem, now the amnesty will place the comment at the end of line properly like this
```
 log.warning('Error in conditional module: \ 
     required module {module} has no {module_attr}'.format(module=module, module_attr=attr_name)). # lint-amnesty, pylint: disable=logging-format-interpolation
```
