### PR TITLE
[BD-21] Lint missing waffle annotations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[5.0.0] - 2021-03-18
+~~~~~~~~~~~~~~~~~~~~
+
 * BREAKING CHANGE: Add linter for invalid imports from Django Waffle (`import waffle` and `from waffle import ...`). Instead, developers should import toggle objects from `edx_toggles.toggles`.
 * BREAKING CHANGE: Add linter for missing feature toggle annotations ("toggle-missing-annotation"). Check `this howto <https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html>`__ for more information on writing toggle annotations.
 * Fix duplicate annotation errors.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* BREAKING CHANGE: Add linter for missing feature toggle annotations ("toggle-missing-annotation"). Check `this howto <https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html>`__ for more information on writing toggle annotations.
 * Fix duplicate annotation errors.
 
 [4.1.1] - 2021-03-16

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,11 +13,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Fix duplicate annotation errors.
+
 [4.1.1] - 2021-03-16
 ~~~~~~~~~~~~~~~~~~~~
 
 * Fixed lint amnesty breakage on line continuation
-
 
 [4.1.0] - 2021-02-24
 ~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* BREAKING CHANGE: Add linter for invalid imports from Django Waffle (`import waffle` and `from waffle import ...`). Instead, developers should import toggle objects from `edx_toggles.toggles`.
 * BREAKING CHANGE: Add linter for missing feature toggle annotations ("toggle-missing-annotation"). Check `this howto <https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html>`__ for more information on writing toggle annotations.
 * Fix duplicate annotation errors.
 

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-VERSION = "4.1.1"
+VERSION = "5.0.0"

--- a/edx_lint/pylint/annotations_check.py
+++ b/edx_lint/pylint/annotations_check.py
@@ -7,6 +7,7 @@ import re
 
 import pkg_resources
 
+from astroid.node_classes import Const, Name
 from code_annotations import annotation_errors
 from code_annotations.base import AnnotationConfig
 from code_annotations.find_static import StaticSearch
@@ -264,6 +265,7 @@ class AnnotationBaseChecker(BaseChecker):
             config = AnnotationConfig(config_path, verbosity=-1)
             search = StaticSearch(config)
             self.config_search.append((config, search))
+            self.current_module_annotations = []
 
     def check_module(self, node):
         """
@@ -272,12 +274,15 @@ class AnnotationBaseChecker(BaseChecker):
         for config, search in self.config_search:
             # This is a hack to avoid re-creating AnnotationConfig every time
             config.source_path = node.path[0]
-            results = search.search()
+            all_results = search.search()
 
-            current_annotations_group = []
-            for _file_name, results in results.items():
-                for current_annotations_group in search.iter_groups(results):
-                    self.check_annotation_group(search, current_annotations_group, node)
+            for _file_name, results in all_results.items():
+                for annotations_group in search.iter_groups(results):
+                    self.current_module_annotations.append(annotations_group)
+                    self.check_annotation_group(search, annotations_group, node)
+
+    def leave_module(self, _node):
+        self.current_module_annotations.clear()
 
     def check_annotation_group(self, search, annotations, node):
         raise NotImplementedError
@@ -341,6 +346,7 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
     EMPTY_DESCRIPTION_MESSAGE_ID = "toggle-empty-description"
     MISSING_TARGET_REMOVAL_DATE_MESSAGE_ID = "toggle-missing-target-removal-date"
     NON_BOOLEAN_DEFAULT_VALUE = "toggle-non-boolean-default-value"
+    MISSING_ANNOTATION = "toggle-missing-annotation"
 
     msgs = {
         ("E%d60" % BASE_ID): (
@@ -363,7 +369,29 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
             NON_BOOLEAN_DEFAULT_VALUE,
             "Feature toggle default values must be boolean",
         ),
+        ("E%d64" % BASE_ID): (
+            "missing feature toggle annotation",
+            MISSING_ANNOTATION,
+            (
+                "When a WaffleFlag/Switch object is created, a corresponding annotation must be present above in the"
+                " same module and with a matching name",
+            )
+        ),
     }
+
+    TOGGLE_FUNC_NAMES = [
+        "WaffleFlag",
+        "NonNamespacedWaffleFlag",
+        "WaffleSwitch",
+        "NonNamespacedWaffleSwitch",
+        "CourseWaffleFlag",
+        "ExperimentWaffleFlag",
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.current_module_annotated_toggle_names = set()
+        self.current_module_annotation_group_line_numbers = []
 
     @check_all_messages(msgs)
     def visit_module(self, node):
@@ -371,6 +399,10 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
         Run all checks on a single module.
         """
         self.check_module(node)
+
+    def leave_module(self, _node):
+        self.current_module_annotated_toggle_names.clear()
+        self.current_module_annotation_group_line_numbers.clear()
 
     def check_annotation_group(self, search, annotations, node):
         """
@@ -388,8 +420,10 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
         for annotation in annotations:
             if line_number is None:
                 line_number = annotation["line_number"]
+                self.current_module_annotation_group_line_numbers.append(line_number)
             if annotation["annotation_token"] == ".. toggle_name:":
                 toggle_name = annotation["annotation_data"]
+                self.current_module_annotated_toggle_names.add(toggle_name)
             elif annotation["annotation_token"] == ".. toggle_description:":
                 toggle_description = annotation["annotation_data"].strip()
             elif annotation["annotation_token"] == ".. toggle_use_cases:":
@@ -427,6 +461,44 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
                 node=node,
                 line=line_number,
             )
+
+    @utils.check_messages(MISSING_ANNOTATION)
+    def visit_call(self, node):
+        """
+        Check for missing annotations.
+        """
+        if self.is_annotation_missing(node):
+            self.add_message(
+                self.MISSING_ANNOTATION,
+                node=node,
+            )
+
+    def is_annotation_missing(self, node):
+        """
+        Check whether the node corresponds to a toggle instance creation. if yes, check that it is annotated.
+        """
+        if (
+            not isinstance(node.func, Name)
+            or node.func.name not in self.TOGGLE_FUNC_NAMES
+        ):
+            return False
+
+        if not self.current_module_annotation_group_line_numbers:
+            # There are no annotations left
+            return True
+
+        annotation_line_number = self.current_module_annotation_group_line_numbers[0]
+        if annotation_line_number > node.tolineno:
+            # The next annotation is located after the current node
+            return True
+        self.current_module_annotation_group_line_numbers.pop(0)
+
+        if node.args and isinstance(node.args[0], Const) and isinstance(node.args[0].value, str):
+            # First argument is constant string and corresponds to the toggle name
+            toggle_name = node.args[0].value
+            if toggle_name not in self.current_module_annotated_toggle_names:
+                return True
+        return False
 
 
 class SettingAnnotationChecker(AnnotationBaseChecker):

--- a/edx_lint/pylint/annotations_check.py
+++ b/edx_lint/pylint/annotations_check.py
@@ -347,6 +347,7 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
     MISSING_TARGET_REMOVAL_DATE_MESSAGE_ID = "toggle-missing-target-removal-date"
     NON_BOOLEAN_DEFAULT_VALUE = "toggle-non-boolean-default-value"
     MISSING_ANNOTATION = "toggle-missing-annotation"
+    INVALID_DJANGO_WAFFLE_IMPORT = "invalid-django-waffle-import"
 
     msgs = {
         ("E%d60" % BASE_ID): (
@@ -375,6 +376,14 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
             (
                 "When a WaffleFlag/Switch object is created, a corresponding annotation must be present above in the"
                 " same module and with a matching name",
+            )
+        ),
+        ("E%d65" % BASE_ID): (
+            "invalid Django Waffle import",
+            INVALID_DJANGO_WAFFLE_IMPORT,
+            (
+                "It is not allowed to directly access Django Waffle objects and methods. Instead, import from"
+                " edx_toggles.toggles.",
             )
         ),
     }
@@ -471,6 +480,22 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
         if self.is_annotation_missing(node):
             self.add_message(
                 self.MISSING_ANNOTATION,
+                node=node,
+            )
+
+    @utils.check_messages(INVALID_DJANGO_WAFFLE_IMPORT)
+    def visit_import(self, node):
+        if node.names[0][0] == "waffle":
+            self.add_message(
+                self.INVALID_DJANGO_WAFFLE_IMPORT,
+                node=node,
+            )
+
+    @utils.check_messages(INVALID_DJANGO_WAFFLE_IMPORT)
+    def visit_importfrom(self, node):
+        if node.modname == "waffle":
+            self.add_message(
+                self.INVALID_DJANGO_WAFFLE_IMPORT,
                 node=node,
             )
 

--- a/edx_lint/pylint/annotations_check.py
+++ b/edx_lint/pylint/annotations_check.py
@@ -323,6 +323,7 @@ class CodeAnnotationChecker(AnnotationBaseChecker):
                 node=node,
                 line=annotation["line_number"],
             )
+        search.annotation_errors.clear()
 
 
 class FeatureToggleAnnotationChecker(AnnotationBaseChecker):

--- a/edx_lint/pylint/annotations_check.py
+++ b/edx_lint/pylint/annotations_check.py
@@ -382,7 +382,7 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
             "invalid Django Waffle import",
             INVALID_DJANGO_WAFFLE_IMPORT,
             (
-                "It is not allowed to directly access Django Waffle objects and methods. Instead, import from"
+                "Do not directly access Django Waffle objects and methods. Instead, import from"
                 " edx_toggles.toggles.",
             )
         ),
@@ -525,7 +525,8 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
             if node.func.name in self.LEGACY_TOGGLE_FUNC_NAMES:
                 # For legacy toggles
                 if isinstance(node.args[1], Const) and isinstance(node.args[1].value, str):
-                    toggle_name = toggle_name + "." + node.args[1].value
+                    namespace = toggle_name
+                    toggle_name = namespace + "." + node.args[1].value
             if toggle_name not in self.current_module_annotated_toggle_names:
                 return True
         return False

--- a/edx_lint/pylint/annotations_check.py
+++ b/edx_lint/pylint/annotations_check.py
@@ -379,6 +379,7 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
         ),
     }
 
+    LEGACY_TOGGLE_FUNC_NAMES = ["LegacyWaffleFlag", "LegacyWaffleSwitch"]
     TOGGLE_FUNC_NAMES = [
         "WaffleFlag",
         "NonNamespacedWaffleFlag",
@@ -386,7 +387,7 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
         "NonNamespacedWaffleSwitch",
         "CourseWaffleFlag",
         "ExperimentWaffleFlag",
-    ]
+    ] + LEGACY_TOGGLE_FUNC_NAMES
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -493,9 +494,13 @@ class FeatureToggleAnnotationChecker(AnnotationBaseChecker):
             return True
         self.current_module_annotation_group_line_numbers.pop(0)
 
+        # Check literal toggle name arguments
         if node.args and isinstance(node.args[0], Const) and isinstance(node.args[0].value, str):
-            # First argument is constant string and corresponds to the toggle name
             toggle_name = node.args[0].value
+            if node.func.name in self.LEGACY_TOGGLE_FUNC_NAMES:
+                # For legacy toggles
+                if isinstance(node.args[1], Const) and isinstance(node.args[1].value, str):
+                    toggle_name = toggle_name + "." + node.args[1].value
             if toggle_name not in self.current_module_annotated_toggle_names:
                 return True
         return False

--- a/test/plugins/pylint_test.py
+++ b/test/plugins/pylint_test.py
@@ -66,7 +66,7 @@ def run_pylint(source, msg_ids, *cmd_args):
 
     reporter = SimpleReporter()
 
-    pylint_args = ["source.py", "--disable=all", f"--enable={msg_ids}", *cmd_args]
+    pylint_args = ["source.py", "--disable=all", f"--enable={msg_ids}", "--load-plugins=edx_lint.pylint", *cmd_args]
     if pylint_numversion >= (2, 0):
         kwargs = dict(do_exit=False)
     else:

--- a/test/plugins/test_annotations_check.py
+++ b/test/plugins/test_annotations_check.py
@@ -254,6 +254,18 @@ def test_missing_annotation():
     assert expected == messages
 
 
+def test_missing_legacy_annotation():
+    source = """
+    # .. toggle_name: MYTOGGLE1
+    waffle1 = LegacyWaffleFlag('MYNAMESPACE', 'MYTOGGLE1')
+    """
+    messages = run_pylint(source, "toggle-missing-annotation")
+    expected = {
+        "3:toggle-missing-annotation:missing feature toggle annotation"
+    }
+    assert expected == messages
+
+
 def test_missing_annotation_for_unnamed_toggle():
     source = """
     # annotated waffle flag

--- a/test/plugins/test_annotations_check.py
+++ b/test/plugins/test_annotations_check.py
@@ -279,3 +279,16 @@ def test_missing_annotation_for_unnamed_toggle():
         "6:toggle-missing-annotation:missing feature toggle annotation"
     }
     assert expected == messages
+
+
+def test_invalid_import_from_django_waffle():
+    source = """
+    from waffle import waffle_is_active
+    import waffle
+    """
+    messages = run_pylint(source, "invalid-django-waffle-import")
+    expected = {
+        "2:invalid-django-waffle-import:invalid Django Waffle import",
+        "3:invalid-django-waffle-import:invalid Django Waffle import",
+    }
+    assert expected == messages

--- a/test/plugins/test_annotations_check.py
+++ b/test/plugins/test_annotations_check.py
@@ -221,3 +221,21 @@ def test_setting_boolean_default_value():
         "2:setting-boolean-default-value:setting annotation (MYSETTING) cannot have a boolean value"
     }
     assert expected == messages
+
+
+def test_no_duplicate_annotation_errors():
+    source = """
+    # .. setting_default: something1
+    # .. setting_description: something1
+    x = 1
+
+    # .. setting_name: MYTOGGLE2
+    # .. setting_default: something2
+    # .. setting_description: something2
+    x = 2
+    """
+    messages = run_pylint(source, "annotation-missing-token")
+    expected = {
+        "2:annotation-missing-token:missing non-optional annotation: '.. setting_name:'"
+    }
+    assert expected == messages

--- a/test/plugins/test_annotations_check.py
+++ b/test/plugins/test_annotations_check.py
@@ -256,7 +256,7 @@ def test_missing_annotation():
 
 def test_missing_legacy_annotation():
     source = """
-    # .. toggle_name: MYTOGGLE1
+    # .. toggle_name: MYNAMESPACE.INCORRECTMYTOGGLE1
     waffle1 = LegacyWaffleFlag('MYNAMESPACE', 'MYTOGGLE1')
     """
     messages = run_pylint(source, "toggle-missing-annotation")

--- a/test/plugins/test_annotations_check.py
+++ b/test/plugins/test_annotations_check.py
@@ -239,3 +239,31 @@ def test_no_duplicate_annotation_errors():
         "2:annotation-missing-token:missing non-optional annotation: '.. setting_name:'"
     }
     assert expected == messages
+
+
+def test_missing_annotation():
+    source = """
+    # .. toggle_name: MYTOGGLE1
+    waffle1 = WaffleFlag('MYTOGGLE1')
+    waffle2 = WaffleFlag('MYTOGGLE2')
+    """
+    messages = run_pylint(source, "toggle-missing-annotation")
+    expected = {
+        "4:toggle-missing-annotation:missing feature toggle annotation"
+    }
+    assert expected == messages
+
+
+def test_missing_annotation_for_unnamed_toggle():
+    source = """
+    # annotated waffle flag
+    # .. toggle_name: MYTOGGLE1
+    waffle1 = CourseWaffleFlag()
+    # unannotated waffle flag
+    waffle2 = ExperimentWaffleFlag()
+    """
+    messages = run_pylint(source, "toggle-missing-annotation")
+    expected = {
+        "6:toggle-missing-annotation:missing feature toggle annotation"
+    }
+    assert expected == messages

--- a/test/plugins/test_ignore_long_lines.py
+++ b/test/plugins/test_ignore_long_lines.py
@@ -2,6 +2,7 @@
 Test ignore-long-lines regex
 """
 # pylint: disable=toggle-no-name,toggle-non-boolean-default-value,annotation-missing-token
+import os
 
 from .pylint_test import run_pylint
 
@@ -30,7 +31,8 @@ def test_ignore_long_lines():
         # .. toggle_description: this is a good toggle, it goes back and forth, toggling a lot, which is what we expect toggles to do.
     """
     msg_ids = "line-too-long"
-    messages = run_pylint(source, msg_ids)
+    rcfile = os.path.join(os.path.dirname(__file__), "..", "..", "pylintrc")
+    messages = run_pylint(source, msg_ids, f"--rcfile={rcfile}")
 
     # normalize the messages by stripping off the 3rd segment.
     messages = {":".join(message.split(":")[:2]) for message in messages}


### PR DESCRIPTION
This PR adds a linter for missing annotations. Here, we only lint (NonNamespaced)WaffleFlag/Switch objects for which the first argument is a string.

Note: this PR also fixes a few unit tests which broke down during the upgrade to pylint 2.6.0.

cc @robrap.