### PR TITLE
Remove base django requirement

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,6 @@
 code-annotations
 click
 click-log
-Django
 pylint
 pylint-django
 pylint-celery

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.4.2
+astroid==2.5
     # via
     #   pylint
     #   pylint-celery
@@ -22,16 +22,15 @@ code-annotations==1.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django==2.2.17
+django==2.2.19
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
-    #   -r requirements/base.in
     #   code-annotations
 isort==5.7.0
     # via pylint
-jinja2==2.11.2
+jinja2==2.11.3
     # via code-annotations
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.5.2
     # via astroid
 markupsafe==1.1.1
     # via jinja2
@@ -60,7 +59,7 @@ pylint==2.6.0
     #   pylint-plugin-utils
 python-slugify==4.0.1
     # via code-annotations
-pytz==2020.5
+pytz==2021.1
     # via django
 pyyaml==5.4.1
     # via code-annotations
@@ -68,7 +67,6 @@ six==1.15.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-    #   astroid
 sqlparse==0.4.1
     # via django
 stevedore==3.3.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-packaging==20.8
+packaging==20.9
     # via tox
 pluggy==0.13.1
     # via tox
@@ -27,7 +27,7 @@ six==1.15.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.21.2
+tox==3.22.0
     # via -r requirements/ci.in
-virtualenv==20.4.0
+virtualenv==20.4.2
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4
     # via virtualenv
-astroid==2.4.2
+astroid==2.5
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -27,7 +27,7 @@ code-annotations==1.1.0
     #   -r requirements/base.txt
 distlib==0.3.1
     # via virtualenv
-django==2.2.17
+django==2.2.19
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -40,11 +40,11 @@ isort==5.7.0
     # via
     #   -r requirements/base.txt
     #   pylint
-jinja2==2.11.2
+jinja2==2.11.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.5.2
     # via
     #   -r requirements/base.txt
     #   astroid
@@ -56,7 +56,7 @@ mccabe==0.6.1
     # via
     #   -r requirements/base.txt
     #   pylint
-packaging==20.8
+packaging==20.9
     # via tox
 pbr==5.5.1
     # via
@@ -92,7 +92,7 @@ python-slugify==4.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
-pytz==2020.5
+pytz==2021.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -104,7 +104,6 @@ six==1.15.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-    #   astroid
     #   tox
     #   virtualenv
 sqlparse==0.4.1
@@ -126,11 +125,11 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/dev.in
-tox==3.21.2
+tox==3.22.0
     # via
     #   -r requirements/dev.in
     #   tox-battery
-virtualenv==20.4.0
+virtualenv==20.4.2
     # via tox
 wrapt==1.12.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/dev.txt
     #   virtualenv
-astroid==2.4.2
+astroid==2.5
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -29,13 +29,13 @@ code-annotations==1.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
-coverage==5.3.1
+coverage==5.4
     # via -r requirements/test.in
 distlib==0.3.1
     # via
     #   -r requirements/dev.txt
     #   virtualenv
-django==2.2.17
+django==2.2.19
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
@@ -52,11 +52,11 @@ isort==5.7.0
     # via
     #   -r requirements/dev.txt
     #   pylint
-jinja2==2.11.2
+jinja2==2.11.3
     # via
     #   -r requirements/dev.txt
     #   code-annotations
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.5.2
     # via
     #   -r requirements/dev.txt
     #   astroid
@@ -68,7 +68,7 @@ mccabe==0.6.1
     # via
     #   -r requirements/dev.txt
     #   pylint
-packaging==20.8
+packaging==20.9
     # via
     #   -r requirements/dev.txt
     #   pytest
@@ -117,7 +117,7 @@ python-slugify==4.0.1
     # via
     #   -r requirements/dev.txt
     #   code-annotations
-pytz==2020.5
+pytz==2021.1
     # via
     #   -r requirements/dev.txt
     #   django
@@ -129,7 +129,6 @@ six==1.15.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
-    #   astroid
     #   tox
     #   virtualenv
 sqlparse==0.4.1
@@ -152,11 +151,11 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/dev.txt
-tox==3.21.2
+tox==3.22.0
     # via
     #   -r requirements/dev.txt
     #   tox-battery
-virtualenv==20.4.0
+virtualenv==20.4.2
     # via
     #   -r requirements/dev.txt
     #   tox


### PR DESCRIPTION
**JIRA Issue:** [BOM-2418](https://openedx.atlassian.net/browse/BOM-2418)
#### Details: 
Removing the `Django` requirement from `base.in` because: 
- `Django` requirement in `base.in` causes the `django` version in [testeng-ci repo](https://github.com/edx/testeng-ci/blob/981773e6a419cc8347183624893c11cde11f93c0/requirements/testing.txt#L50) to upgrade to `django==3.1.6` which causes failures in different [jobs](https://build.testeng.edx.org/job/travis-job-counts/259251/console). 
- It upgrades the Django version to 3+ in any repo that uses this package without applying constraint on `Django` versions.