### PR TITLE
BOM-2465: Unpin social-auth-core

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -10,7 +10,3 @@
 
 # using LTS django version
 Django<2.3
-
-# Pinned social-auth-core to <4.0.3 untill drf-jwt adds support for PyJWT>2.0
-# https://github.com/Styria-Digital/django-rest-framework-jwt/issues/76 
-social-auth-core<4.0.3


### PR DESCRIPTION
The problem mentioned for constraint's reason is fixed in https://github.com/Styria-Digital/django-rest-framework-jwt/pull/91 , so we are unpinning it.