### PR TITLE
docs: add bug report link to constraint

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -16,4 +16,5 @@ Django<2.3
 social-auth-core<4.0.3
 
 # docutils version 0.17 is causing docs rendering to fail
+# See https://sourceforge.net/p/docutils/bugs/417/
 docutils==0.16


### PR DESCRIPTION
For docutils constraint, adds a link to the bug report.