### PR TITLE
BOM-2482: Pin pylint<2.8.0

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -5,7 +5,7 @@
 # It specifies version constraints that will be applied if a package is needed.
 # When pinning something here, please provide an explanation of why it is a good
 # idea to pin this package across all edx repos, Ideally, link to other information
-# that will help people in the future to remove the pin when possible.  
+# that will help people in the future to remove the pin when possible.
 # Writing an issue against the offending project and linking to it here is good.
 #
 # Note: Changes to this file will automatically be used by other repos, referencing
@@ -18,3 +18,7 @@ Django<2.3
 # docutils version 0.17 is causing docs rendering to fail
 # See https://sourceforge.net/p/docutils/bugs/417/
 docutils==0.16
+
+# pylint.__pkginfo__.numversion conflicts with pylint-django.
+# Can be removed once https://github.com/PyCQA/pylint-django/issues/323 is fixed.
+pylint<2.8.0


### PR DESCRIPTION
**Issue:** [BOM-2482](https://openedx.atlassian.net/browse/BOM-2482)

### Description
- Pinning pylint version to resolve `pkginfo version check conflict` with pylint-django. 
