### PR TITLE
BOM-2496: remove pylint common constraint

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -18,7 +18,3 @@ Django<2.3
 # docutils version 0.17 is causing docs rendering to fail
 # See https://sourceforge.net/p/docutils/bugs/417/
 docutils==0.16
-
-# pylint.__pkginfo__.numversion conflicts with pylint-django.
-# Can be removed once https://github.com/PyCQA/pylint-django/issues/323 is fixed.
-pylint<2.8.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,25 +18,25 @@ click==7.1.2
     #   -r requirements/base.in
     #   click-log
     #   code-annotations
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django==2.2.19
+django==2.2.20
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   code-annotations
-isort==5.7.0
+isort==5.8.0
     # via pylint
 jinja2==2.11.3
     # via code-annotations
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
     # via pylint
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
 pylint-celery==0.3
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -27,7 +27,7 @@ six==1.15.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.22.0
+tox==3.23.0
     # via -r requirements/ci.in
-virtualenv==20.4.2
+virtualenv==20.4.4
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,13 +21,13 @@ click==7.1.2
     #   -r requirements/base.txt
     #   click-log
     #   code-annotations
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
 distlib==0.3.1
     # via virtualenv
-django==2.2.19
+django==2.2.20
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -36,7 +36,7 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-isort==5.7.0
+isort==5.8.0
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -44,7 +44,7 @@ jinja2==2.11.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via
     #   -r requirements/base.txt
     #   astroid
@@ -58,7 +58,7 @@ mccabe==0.6.1
     #   pylint
 packaging==20.9
     # via tox
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -125,11 +125,11 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/dev.in
-tox==3.22.0
+tox==3.23.0
     # via
     #   -r requirements/dev.in
     #   tox-battery
-virtualenv==20.4.2
+virtualenv==20.4.4
     # via tox
 wrapt==1.12.1
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,8 +6,12 @@
 #
 click==7.1.2
     # via pip-tools
-pip-tools==5.5.0
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.1.0
     # via -r requirements/pip-tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,17 +25,17 @@ click==7.1.2
     #   -r requirements/dev.txt
     #   click-log
     #   code-annotations
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
-coverage==5.4
+coverage==5.5
     # via -r requirements/test.in
 distlib==0.3.1
     # via
     #   -r requirements/dev.txt
     #   virtualenv
-django==2.2.19
+django==2.2.20
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
@@ -48,7 +48,7 @@ filelock==3.0.12
     #   virtualenv
 iniconfig==1.1.1
     # via pytest
-isort==5.7.0
+isort==5.8.0
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -56,7 +56,7 @@ jinja2==2.11.3
     # via
     #   -r requirements/dev.txt
     #   code-annotations
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via
     #   -r requirements/dev.txt
     #   astroid
@@ -73,7 +73,7 @@ packaging==20.9
     #   -r requirements/dev.txt
     #   pytest
     #   tox
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/dev.txt
     #   stevedore
@@ -111,7 +111,7 @@ pyparsing==2.4.7
     # via
     #   -r requirements/dev.txt
     #   packaging
-pytest==6.2.2
+pytest==6.2.3
     # via -r requirements/test.in
 python-slugify==4.0.1
     # via
@@ -151,11 +151,11 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/dev.txt
-tox==3.22.0
+tox==3.23.0
     # via
     #   -r requirements/dev.txt
     #   tox-battery
-virtualenv==20.4.2
+virtualenv==20.4.4
     # via
     #   -r requirements/dev.txt
     #   tox


### PR DESCRIPTION
**Issue:** [BOM-2496](https://openedx.atlassian.net/browse/BOM-2496)

## Description
- `pylint-django==2.4.4` fixed the `pkginfo.version` issue conflict between `pylint` & `pylint-django` so now the constraint can be removed. 