### PR TITLE
BOM-2513: Pin the django<2.2.21

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -12,8 +12,11 @@
 #  this file from Github directly. It does not require packaging in edx-lint.
 
 
-# using LTS django version
-Django<2.3
+# Django version==2.2.21 fixed a security vulnerability related to file paths.
+# https://code.djangoproject.com/ticket/32718 is addressing this issue.
+# This update broke the tests in edx-platform so the tests need to be fixed for the upgrade.
+# https://openedx.atlassian.net/browse/BOM-2513 is fixing the tests for the upgrade.
+Django<2.2.21
 
 # docutils version 0.17 is causing docs rendering to fail
 # See https://sourceforge.net/p/docutils/bugs/417/


### PR DESCRIPTION
**JIRA Issue:** [BOM-2513](https://openedx.atlassian.net/browse/BOM-2513)

## Description
`django==2.2.21` fixed a [security vulnerability](https://docs.djangoproject.com/en/3.2/releases/2.2.21/) by adding sanity checks for empty file paths for uploaded files.
This broke the tests hence pinning the version to fix the tests.

https://code.djangoproject.com/ticket/32718 is addressing this issue. 
This constraint will be removed once the tests has been fixed according to the advised solution.