### PR TITLE
fix: pin click<8.0 version

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -22,3 +22,5 @@ docutils==0.16
 # Newer versions causing tests failures in multiple repos.
 pyjwt[crypto]==1.7.1
 
+# click>=8.0.0 causes conflicts with Sphinx>=4.0.0(which requires jinja2<3.2, click<8.0)
+click<8.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ click-log==0.3.2
     #   -r requirements/base.in
 click==7.1.2
     # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   click-log
@@ -22,17 +23,19 @@ code-annotations==1.1.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django==2.2.20
+django==2.2.23
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   code-annotations
+importlib-metadata==4.0.1
+    # via stevedore
 isort==5.8.0
     # via pylint
-jinja2==2.11.3
+jinja2==3.0.0
     # via code-annotations
 lazy-object-proxy==1.6.0
     # via astroid
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via jinja2
 mccabe==0.6.1
     # via pylint
@@ -57,13 +60,13 @@ pylint==2.6.0
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via code-annotations
 pytz==2021.1
     # via django
 pyyaml==5.4.1
     # via code-annotations
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -75,5 +78,11 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pylint
+typed-ast==1.4.3
+    # via astroid
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 wrapt==1.12.1
     # via astroid
+zipp==3.4.1
+    # via importlib-metadata

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,6 +12,13 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
+importlib-metadata==4.0.1
+    # via
+    #   pluggy
+    #   tox
+    #   virtualenv
+importlib-resources==5.1.3
+    # via virtualenv
 packaging==20.9
     # via tox
 pluggy==0.13.1
@@ -20,14 +27,20 @@ py==1.10.0
     # via tox
 pyparsing==2.4.7
     # via packaging
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/constraints.txt
     #   tox
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.23.0
+tox==3.23.1
     # via -r requirements/ci.in
-virtualenv==20.4.4
+typing-extensions==3.10.0.0
+    # via importlib-metadata
+virtualenv==20.4.6
     # via tox
+zipp==3.4.1
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,6 +17,7 @@ click-log==0.3.2
     #   -r requirements/base.txt
 click==7.1.2
     # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   click-log
@@ -27,7 +28,7 @@ code-annotations==1.1.1
     #   -r requirements/base.txt
 distlib==0.3.1
     # via virtualenv
-django==2.2.20
+django==2.2.23
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -36,11 +37,20 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
+importlib-metadata==4.0.1
+    # via
+    #   -r requirements/base.txt
+    #   pluggy
+    #   stevedore
+    #   tox
+    #   virtualenv
+importlib-resources==5.1.3
+    # via virtualenv
 isort==5.8.0
     # via
     #   -r requirements/base.txt
     #   pylint
-jinja2==2.11.3
+jinja2==3.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -48,7 +58,7 @@ lazy-object-proxy==1.6.0
     # via
     #   -r requirements/base.txt
     #   astroid
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -88,7 +98,7 @@ pylint==2.6.0
     #   pylint-plugin-utils
 pyparsing==2.4.7
     # via packaging
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -100,7 +110,7 @@ pyyaml==5.4.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -125,13 +135,26 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/dev.in
-tox==3.23.0
+tox==3.23.1
     # via
     #   -r requirements/dev.in
     #   tox-battery
-virtualenv==20.4.4
+typed-ast==1.4.3
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/base.txt
+    #   importlib-metadata
+virtualenv==20.4.6
     # via tox
 wrapt==1.12.1
     # via
     #   -r requirements/base.txt
     #   astroid
+zipp==3.4.1
+    # via
+    #   -r requirements/base.txt
+    #   importlib-metadata
+    #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
-click==7.1.2
+click==8.0.0
     # via pip-tools
+importlib-metadata==4.0.1
+    # via pep517
 pep517==0.10.0
     # via pip-tools
 pip-tools==6.1.0
     # via -r requirements/pip-tools.in
 toml==0.10.2
     # via pep517
+typing-extensions==3.10.0.0
+    # via importlib-metadata
+zipp==3.4.1
+    # via
+    #   importlib-metadata
+    #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ astroid==2.5
     #   -r requirements/dev.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via pytest
 click-log==0.3.2
     # via
@@ -21,6 +21,7 @@ click-log==0.3.2
     #   -r requirements/dev.txt
 click==7.1.2
     # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   click-log
@@ -35,7 +36,7 @@ distlib==0.3.1
     # via
     #   -r requirements/dev.txt
     #   virtualenv
-django==2.2.20
+django==2.2.23
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
@@ -46,13 +47,25 @@ filelock==3.0.12
     #   -r requirements/dev.txt
     #   tox
     #   virtualenv
+importlib-metadata==4.0.1
+    # via
+    #   -r requirements/dev.txt
+    #   pluggy
+    #   pytest
+    #   stevedore
+    #   tox
+    #   virtualenv
+importlib-resources==5.1.3
+    # via
+    #   -r requirements/dev.txt
+    #   virtualenv
 iniconfig==1.1.1
     # via pytest
 isort==5.8.0
     # via
     #   -r requirements/dev.txt
     #   pylint
-jinja2==2.11.3
+jinja2==3.0.0
     # via
     #   -r requirements/dev.txt
     #   code-annotations
@@ -60,7 +73,7 @@ lazy-object-proxy==1.6.0
     # via
     #   -r requirements/dev.txt
     #   astroid
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via
     #   -r requirements/dev.txt
     #   jinja2
@@ -111,9 +124,9 @@ pyparsing==2.4.7
     # via
     #   -r requirements/dev.txt
     #   packaging
-pytest==6.2.3
+pytest==6.2.4
     # via -r requirements/test.in
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/dev.txt
     #   code-annotations
@@ -125,7 +138,7 @@ pyyaml==5.4.1
     # via
     #   -r requirements/dev.txt
     #   code-annotations
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
@@ -151,11 +164,19 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/dev.txt
-tox==3.23.0
+tox==3.23.1
     # via
     #   -r requirements/dev.txt
     #   tox-battery
-virtualenv==20.4.4
+typed-ast==1.4.3
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/dev.txt
+    #   importlib-metadata
+virtualenv==20.4.6
     # via
     #   -r requirements/dev.txt
     #   tox
@@ -163,3 +184,8 @@ wrapt==1.12.1
     # via
     #   -r requirements/dev.txt
     #   astroid
+zipp==3.4.1
+    # via
+    #   -r requirements/dev.txt
+    #   importlib-metadata
+    #   importlib-resources


### PR DESCRIPTION
click>=8.0.0 causes conflicts with Sphinx latest version in make upgrade job.
failing builds:
- https://github.com/edx/edx-django-utils/runs/2597892035?check_suite_focus=true
- https://github.com/edx/xss-utils/runs/2597405478?check_suite_focus=true
- https://github.com/edx/django-config-models/runs/2597212205?check_suite_focus=true
