### PR TITLE
Pinned Jinja2 and MarkupSafe versions in common constraints

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -24,3 +24,7 @@ pyjwt[crypto]==1.7.1
 
 # click>=8.0.0 causes conflicts with Sphinx>=4.0.0(which requires jinja2<3.2, click<8.0)
 click<8.0.0
+
+# Sphinx>=4.0.1 requires Jinja2<3.0.0, MarkupSafe<2.0.0 (Can be removed once Sphinx==4.0.2 is released)
+Jinja2<3.0.0
+MarkupSafe<2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,16 +27,18 @@ django==2.2.23
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   code-annotations
-importlib-metadata==4.0.1
-    # via stevedore
 isort==5.8.0
     # via pylint
-jinja2==3.0.0
-    # via code-annotations
+jinja2==2.11.3
+    # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
+    #   code-annotations
 lazy-object-proxy==1.6.0
     # via astroid
-markupsafe==2.0.0
-    # via jinja2
+markupsafe==1.1.1
+    # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
+    #   jinja2
 mccabe==0.6.1
     # via pylint
 pbr==5.6.0
@@ -78,11 +80,5 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pylint
-typed-ast==1.4.3
-    # via astroid
-typing-extensions==3.10.0.0
-    # via importlib-metadata
 wrapt==1.12.1
     # via astroid
-zipp==3.4.1
-    # via importlib-metadata

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,13 +12,6 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-importlib-metadata==4.0.1
-    # via
-    #   pluggy
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.3
-    # via virtualenv
 packaging==20.9
     # via tox
 pluggy==0.13.1
@@ -36,11 +29,5 @@ toml==0.10.2
     # via tox
 tox==3.23.1
     # via -r requirements/ci.in
-typing-extensions==3.10.0.0
-    # via importlib-metadata
 virtualenv==20.4.6
     # via tox
-zipp==3.4.1
-    # via
-    #   importlib-metadata
-    #   importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -37,29 +37,22 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-importlib-metadata==4.0.1
-    # via
-    #   -r requirements/base.txt
-    #   pluggy
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.3
-    # via virtualenv
 isort==5.8.0
     # via
     #   -r requirements/base.txt
     #   pylint
-jinja2==3.0.0
+jinja2==2.11.3
     # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
 lazy-object-proxy==1.6.0
     # via
     #   -r requirements/base.txt
     #   astroid
-markupsafe==2.0.0
+markupsafe==1.1.1
     # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   jinja2
 mccabe==0.6.1
@@ -139,22 +132,9 @@ tox==3.23.1
     # via
     #   -r requirements/dev.in
     #   tox-battery
-typed-ast==1.4.3
-    # via
-    #   -r requirements/base.txt
-    #   astroid
-typing-extensions==3.10.0.0
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 virtualenv==20.4.6
     # via tox
 wrapt==1.12.1
     # via
     #   -r requirements/base.txt
     #   astroid
-zipp==3.4.1
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
-    #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,20 +6,12 @@
 #
 click==8.0.0
     # via pip-tools
-importlib-metadata==4.0.1
-    # via pep517
 pep517==0.10.0
     # via pip-tools
 pip-tools==6.1.0
     # via -r requirements/pip-tools.in
 toml==0.10.2
     # via pep517
-typing-extensions==3.10.0.0
-    # via importlib-metadata
-zipp==3.4.1
-    # via
-    #   importlib-metadata
-    #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,34 +47,24 @@ filelock==3.0.12
     #   -r requirements/dev.txt
     #   tox
     #   virtualenv
-importlib-metadata==4.0.1
-    # via
-    #   -r requirements/dev.txt
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.3
-    # via
-    #   -r requirements/dev.txt
-    #   virtualenv
 iniconfig==1.1.1
     # via pytest
 isort==5.8.0
     # via
     #   -r requirements/dev.txt
     #   pylint
-jinja2==3.0.0
+jinja2==2.11.3
     # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
     #   code-annotations
 lazy-object-proxy==1.6.0
     # via
     #   -r requirements/dev.txt
     #   astroid
-markupsafe==2.0.0
+markupsafe==1.1.1
     # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
     #   jinja2
 mccabe==0.6.1
@@ -168,14 +158,6 @@ tox==3.23.1
     # via
     #   -r requirements/dev.txt
     #   tox-battery
-typed-ast==1.4.3
-    # via
-    #   -r requirements/dev.txt
-    #   astroid
-typing-extensions==3.10.0.0
-    # via
-    #   -r requirements/dev.txt
-    #   importlib-metadata
 virtualenv==20.4.6
     # via
     #   -r requirements/dev.txt
@@ -184,8 +166,3 @@ wrapt==1.12.1
     # via
     #   -r requirements/dev.txt
     #   astroid
-zipp==3.4.1
-    # via
-    #   -r requirements/dev.txt
-    #   importlib-metadata
-    #   importlib-resources


### PR DESCRIPTION
## Description
`Sphinx>=4.0.1` requires `Jinja2<3.0.0` and `MarkupSafe<2.0.0` which conflicts with latest package versions and causes following build failures: 
- https://build.testeng.edx.org/job/event-routing-backends-upgrade-python-requirements/31/console
- https://github.com/edx/edx-cookiecutters/runs/2598651286?check_suite_focus=true
## Solution
Pinned jinja2 and MarkupSafe versions to resolve the issue.
`Sphinx==4.0.2` release is [in-queue](https://github.com/sphinx-doc/sphinx/issues/9214) right now. It can be removed once `Sphinx==4.0.2` is released.