### PR TITLE
BOM-2547: Removed Sphinx related common constraints

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -19,15 +19,8 @@ Django<2.3
 # See https://sourceforge.net/p/docutils/bugs/417/
 docutils==0.16
 
-# latest version is causing e2e failures in edx-platform. 
+# latest version is causing e2e failures in edx-platform.
 drf-jwt<1.19.1
 
 # Newer versions causing tests failures in multiple repos.
 pyjwt[crypto]==1.7.1
-
-# click>=8.0.0 causes conflicts with Sphinx>=4.0.0(which requires jinja2<3.2, click<8.0)
-click<8.0.0
-
-# Sphinx>=4.0.1 requires Jinja2<3.0.0, MarkupSafe<2.0.0 (Can be removed once Sphinx==4.0.2 is released)
-Jinja2<3.0.0
-MarkupSafe<2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,6 @@ click-log==0.3.2
     #   -r requirements/base.in
 click==7.1.2
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   click-log
@@ -29,16 +28,12 @@ django==2.2.23
     #   code-annotations
 isort==5.8.0
     # via pylint
-jinja2==2.11.3
-    # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
-    #   code-annotations
+jinja2==3.0.1
+    # via code-annotations
 lazy-object-proxy==1.6.0
     # via astroid
-markupsafe==1.1.1
-    # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
-    #   jinja2
+markupsafe==2.0.1
+    # via jinja2
 mccabe==0.6.1
     # via pylint
 pbr==5.6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,6 @@ click-log==0.3.2
     #   -r requirements/base.txt
 click==7.1.2
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   click-log
@@ -41,18 +40,16 @@ isort==5.8.0
     # via
     #   -r requirements/base.txt
     #   pylint
-jinja2==2.11.3
+jinja2==3.0.1
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
 lazy-object-proxy==1.6.0
     # via
     #   -r requirements/base.txt
     #   astroid
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   jinja2
 mccabe==0.6.1

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-click==8.0.0
+click==8.0.1
     # via pip-tools
 pep517==0.10.0
     # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,7 +21,6 @@ click-log==0.3.2
     #   -r requirements/dev.txt
 click==7.1.2
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   click-log
@@ -53,18 +52,16 @@ isort==5.8.0
     # via
     #   -r requirements/dev.txt
     #   pylint
-jinja2==2.11.3
+jinja2==3.0.1
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
     #   code-annotations
 lazy-object-proxy==1.6.0
     # via
     #   -r requirements/dev.txt
     #   astroid
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
     #   jinja2
 mccabe==0.6.1


### PR DESCRIPTION

**Issue:** [BOM-2547](https://openedx.atlassian.net/browse/BOM-2547)

### Description
- `Click`, `Jinja2` and `MarkupSafe` were pinned due to `Sphinx` conflict issue which has been fixed in the new `Sphinx==4.0.2` release.