### PR TITLE
chore: pip is not working properly and giving conflicts errors betwee…

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -13,7 +13,7 @@
 
 
 # using LTS django version
-Django<2.3
+Django==2.2.24
 
 # docutils version 0.17 is causing docs rendering to fail
 # See https://sourceforge.net/p/docutils/bugs/417/


### PR DESCRIPTION
 pip is not working properly and giving conflicts error giving conflicts errors between django==2.2.24 and django<2.3.
This issue was appearing only in edx-proctoring.
```
Incompatible requirements found: Django<2.3 (from -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt (line 16)) and django==2.2.24 (from -r requirements/base.txt (line 54))
make: *** [requirements] Error 2
```