### PR TITLE
fix: no need to pin docutils

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -15,10 +15,6 @@
 # using LTS django version
 Django<2.3
 
-# docutils version 0.17 is causing docs rendering to fail
-# See https://sourceforge.net/p/docutils/bugs/417/
-docutils==0.16
-
 # latest version is causing e2e failures in edx-platform.
 drf-jwt<1.19.1
 


### PR DESCRIPTION
An update to edx-sphinx-theme means we don't have to pin docutils
anymore: https://github.com/edx/edx-sphinx-theme/pull/111

We can merge this pull request once the edx-sphinx-theme pull request is merged, and a version pushed to PyPI.