### PR TITLE
feat: Adding a constraint for social-auth-core that is caused by other common constraints

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -20,3 +20,6 @@ drf-jwt<1.19.1
 
 # Newer versions causing tests failures in multiple repos.
 pyjwt[crypto]==1.7.1
+
+# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
+social-auth-core<4.0.3


### PR DESCRIPTION
The constraints that block us from upgrading social-auth-core are part of the common constraints file. I am moving the social-auth-core constraint here as well to make it clear that there is a relationship.