### PR TITLE
fix: add pyjwt related constraints

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -16,13 +16,24 @@
 Django<2.3
 
 # latest version is causing e2e failures in edx-platform.
+# See pyjwt[crypto]<2.0.0 comment.
 drf-jwt<1.19.1
 
-# Newer versions causing tests failures in multiple repos.
-pyjwt[crypto]==1.7.1
+# 4.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
+edx-auth-backends<4.0.0
 
-# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
-social-auth-core<4.0.3
+# 7.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
+edx-drf-extensions<7.0.0
+
+# PyJWT[crypto] 2.0.0 has a number of breaking changes that we are
+# actively working to fix. A number of the active constraints are all related
+# to this effort. Additionally, your IDA/service may also be affected directly
+# by these changes. You should not upgrade without knowing what you are doing.
+pyjwt[crypto]<2.0.0
 
 # 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
 social-auth-app-django<5.0.0
+
+# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
+# See pyjwt[crypto]<2.0.0 comment.
+social-auth-core<4.0.3


### PR DESCRIPTION
Add constraints to stop make upgrading from picking up
newer versions of libraries that require pyjwt 2.1.0
until we are ready for all services to upgrade.