### PR TITLE
fix: pin elasticsearch<7.14.0 version

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -37,3 +37,7 @@ social-auth-app-django<5.0.0
 # latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
 # See pyjwt[crypto]<2.0.0 comment.
 social-auth-core<4.0.3
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elastic-search<7.14.0


### PR DESCRIPTION
### Description
- elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
- elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html