### PR TITLE
fix: Use correct package name for pinning elasticsearch

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -40,4 +40,4 @@ social-auth-core<4.0.3
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
-elastic-search<7.14.0
+elasticsearch<7.14.0


### PR DESCRIPTION
### Description
- [PR](https://github.com/edx/edx-lint/pull/183) pinned elastic search package in common constraints but used the incorrect package name `elastic-search` so updating it with correct package name `elasticsearch`.