### PR TITLE
fix: pin pluggy while pytest and tox coordinate

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -41,3 +41,7 @@ social-auth-core<4.0.3
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
+
+# pluggy released 1.0.0, but pytest limits to <1.0.0 and tox does not, so they disagree on the version to use.
+# This pin can be removed once pytest ships 6.2.5 which will remove the upper limit on the pluggy version.
+pluggy<1.0.0


### PR DESCRIPTION
pytest asks for "pluggy>=0.12,<1.0.0a1"
tox asks for "pluggy>=0.12.0"

Pluggy released 1.0.0 today, so tox wants 1.0.0, and pytest wants 0.13.0, and pip-tools can't find a version to use.

Pinning pluggy until pytest updates their requirement.