### PR TITLE
build: update pylint, and the messages we disable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Silence the "consider-using-f-string" pylint violation.
+
 * The new "update" command will write all edx-lint-writable files that exist
   on disk.
 

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -295,6 +295,7 @@ disable=
     # These should be left to the discretion of the reviewer
     bad-continuation,
     bad-indentation,
+    consider-using-f-string,
     duplicate-code,
     file-ignored,
     fixme,

--- a/pylintrc
+++ b/pylintrc
@@ -315,6 +315,7 @@ enable =
 disable = 
 	bad-continuation,
 	bad-indentation,
+	consider-using-f-string,
 	duplicate-code,
 	file-ignored,
 	fixme,
@@ -483,4 +484,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 4303760e373fa1342225c52294661ccae5902b3c
+# a3b3d132ed233781254fafa64b208fb0b60f759e

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,20 +4,17 @@
 #
 #    make upgrade
 #
-astroid==2.5
+astroid==2.8.0
     # via
     #   pylint
     #   pylint-celery
 click==8.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   click-log
     #   code-annotations
 click-log==0.3.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
 code-annotations==1.2.0
     # via
     #   -c requirements/constraints.txt
@@ -34,21 +31,18 @@ mccabe==0.6.1
     # via pylint
 pbr==5.6.0
     # via stevedore
-pylint==2.6.0
+platformdirs==2.3.0
+    # via pylint
+pylint==2.11.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
-pylint-django==2.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
+pylint-django==2.4.4
+    # via -r requirements/base.in
 pylint-plugin-utils==0.6
     # via
     #   pylint-celery
@@ -58,14 +52,19 @@ python-slugify==5.0.2
 pyyaml==5.4.1
     # via code-annotations
 six==1.16.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
 stevedore==3.4.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pylint
+typing-extensions==3.10.0.2
+    # via
+    #   astroid
+    #   pylint
 wrapt==1.12.1
     # via astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,7 +6,7 @@
 #
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-distlib==0.3.2
+distlib==0.3.3
     # via virtualenv
 filelock==3.0.12
     # via
@@ -24,7 +24,6 @@ pyparsing==2.4.7
     # via packaging
 six==1.16.0
     # via
-    #   -c requirements/constraints.txt
     #   tox
     #   virtualenv
 toml==0.10.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -2,10 +2,3 @@
 -c ../edx_lint/files/common_constraints.txt
 
 code-annotations>=1.1.0
-# Note that these requirements are pinned in order to provide a pinned pylint version for all dependent projects.
-pylint==2.6.0
-pylint-django==2.3.0
-pylint-celery==0.3
-six>=1.10.0,<2.0.0
-click>=6.0
-click-log==0.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.5
+astroid==2.8.0
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -13,19 +13,16 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 click==8.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   click-log
     #   code-annotations
 click-log==0.3.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+    # via -r requirements/base.txt
 code-annotations==1.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-distlib==0.3.2
+distlib==0.3.3
     # via virtualenv
 filelock==3.0.12
     # via
@@ -58,26 +55,24 @@ pbr==5.6.0
     #   -r requirements/base.txt
     #   stevedore
 platformdirs==2.3.0
-    # via virtualenv
+    # via
+    #   -r requirements/base.txt
+    #   pylint
+    #   virtualenv
 pluggy==1.0.0
     # via tox
 py==1.10.0
     # via tox
-pylint==2.6.0
+pylint==2.11.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
-pylint-django==2.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+    # via -r requirements/base.txt
+pylint-django==2.4.4
+    # via -r requirements/base.txt
 pylint-plugin-utils==0.6
     # via
     #   -r requirements/base.txt
@@ -95,7 +90,6 @@ pyyaml==5.4.1
     #   code-annotations
 six==1.16.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   tox
     #   virtualenv
@@ -118,9 +112,17 @@ tox==3.24.4
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
+typing-extensions==3.10.0.2
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+    #   pylint
 virtualenv==20.8.0
     # via tox
 wrapt==1.12.1
     # via
     #   -r requirements/base.txt
     #   astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.1
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.2.0
+pip-tools==6.3.0
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.5
+astroid==2.8.0
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -17,21 +17,18 @@ backports.entry-points-selectable==1.1.0
     #   virtualenv
 click==8.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   click-log
     #   code-annotations
 click-log==0.3.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.txt
+    # via -r requirements/dev.txt
 code-annotations==1.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
 coverage==5.5
     # via -r requirements/test.in
-distlib==0.3.2
+distlib==0.3.3
     # via
     #   -r requirements/dev.txt
     #   virtualenv
@@ -78,6 +75,7 @@ pbr==5.6.0
 platformdirs==2.3.0
     # via
     #   -r requirements/dev.txt
+    #   pylint
     #   virtualenv
 pluggy==1.0.0
     # via
@@ -89,21 +87,16 @@ py==1.10.0
     #   -r requirements/dev.txt
     #   pytest
     #   tox
-pylint==2.6.0
+pylint==2.11.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.txt
-pylint-django==2.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.txt
+    # via -r requirements/dev.txt
+pylint-django==2.4.4
+    # via -r requirements/dev.txt
 pylint-plugin-utils==0.6
     # via
     #   -r requirements/dev.txt
@@ -127,7 +120,6 @@ pyyaml==5.4.1
     #   code-annotations
 six==1.16.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   tox
     #   virtualenv
@@ -153,6 +145,11 @@ tox==3.24.4
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.txt
+typing-extensions==3.10.0.2
+    # via
+    #   -r requirements/dev.txt
+    #   astroid
+    #   pylint
 virtualenv==20.8.0
     # via
     #   -r requirements/dev.txt
@@ -161,3 +158,6 @@ wrapt==1.12.1
     # via
     #   -r requirements/dev.txt
     #   astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ def load_requirements(*requirements_paths):
     """
     requirements = set()
     for path in requirements_paths:
-        requirements.update(
-            line.split('#')[0].strip() for line in open(path).readlines()
-            if is_requirement(line.strip())
-        )
+        with open(path) as req_file:
+            requirements.update(
+                line.split('#')[0].strip() for line in req_file
+                if is_requirement(line.strip())
+            )
     return list(requirements)
 
 


### PR DESCRIPTION
**Description:**

- Remove our local pylint pin, so that we use the same version of pylint as everyone else
- Silence a new violation: "consider using an f-string".  This is not a problem that should fail builds.
- Fix one violation in setup.py

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [ ] Commits are squashed
