### PR TITLE
build: switch to common commitlint action from org template

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,14 +1,37 @@
+# Run commitlint on the commit messasges in a pull request.
+
 name: Lint Commit Messages
+
 on:
   - pull_request
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out the repo
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+
+      - name: Check for a local configuration file
+        id: check
+        run: |
+          if [[ ! -f commitlint.config.js ]]; then
+            echo "::set-output name=need::yes"
+          fi
+
+      - name: Download configuration if needed
+        if: steps.check.outputs.need == 'yes'
+        uses: wei/wget@v1
+        with:
+          args: -O commitlint.config.js https://raw.githubusercontent.com/edx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v4
         with:
           helpURL: https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html


### PR DESCRIPTION
**Description:**

This syncs us up with edx/.github/workflows/commitlint.yml

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [ ] Commits are squashed
