### PR TITLE
fix: pin pip<25.3 to resolve make upgrade build failure

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -18,3 +18,10 @@ Django<5.0
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
+
+# pip 25.3 is incompatible with pip-tools hence causing failures during the build process 
+# Make upgrade command and all requirements upgrade jobs are broken due to this.
+# See issue https://github.com/openedx/public-engineering/issues/440 for details regarding the ongoing fix.
+# The constraint can be removed once a release (pip-tools > 7.5.1) is available with support for pip 25.3
+# Issue to track this dependency and unpin later on: https://github.com/openedx/edx-lint/issues/503
+pip<25.3


### PR DESCRIPTION
## Description
Issue tracking this change: https://github.com/openedx/public-engineering/issues/440
`pip==25.3` is currently not compatible with pip-tools hence causing the build failures and pinning the `pip` version is the only solution to resolve the blockers in our upgrade process for now. 

## Findings
- The error is stemming from the removal of the legacy `setup.py bdist_wheel` support in [pip](https://github.com/pypa/pip/issues/6334) which removes the optional flag `--use-pip517` that had been added for the support of deprecated legacy functionality. 
- Since all versions of `pip-tools` utilize this flag for the `pip-compile` command, the new version `pip==25.3` is now breaking with all the versions of `pip-tools` hence the need to pin `pip` as a solution for this until pip-tools provide a workaround for this issue in their next release.
- Alternatively, it can be explored to keep using latest `pip` version and switch to the new build setup instead of relying on legacy `setup.py bdist_wheel` but this needs a separate discovery effort and is out of scope for the current issue.

## HOW TO TEST
- In any openedx package/service, verify that `pip` version in `requirements/pip.txt` is set to `pip==25.2`
- Add constraint `pip<25.3` in `requirements/constraints.txt` 
- Run `make upgrade` in the package/service shell to test the upgrade job
- The upgrade job should run successfully now without raising the error. 

## VALIDATE CONSTRAINT Selection
- In the `requirements/constraints.txt` pin `pip-tools<7.5.*` instead of pinning `pip<25.3`
- Run `make upgrade`
- It should still fail proving that pinning the `pip-tools` version doesn't fix our error but pinning `pip<25.3` does.