### PR TITLE
Dropped django 4.2 support. Bumped dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.12']
-        toxenv: [pylint, django42, django52]
+        toxenv: [pylint, django52]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Dropped Django 4.2 support; bumped code-annotations to 3.0.0
+
 5.7.0 - 2025-04-21
 ~~~~~~~~~~~~~~~~~~
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ click==8.3.1
     #   code-annotations
 click-log==0.4.0
     # via -r requirements/base.in
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-cachetools==7.0.3
+cachetools==7.0.5
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   python-discovery
     #   tox
@@ -28,11 +28,11 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.1.0
+python-discovery==1.2.0
     # via virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.50.3
     # via -r requirements/ci.in
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ click==8.3.1
     #   code-annotations
 click-log==0.4.0
     # via -r requirements/base.txt
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -26,7 +26,7 @@ dill==0.4.1
     #   pylint
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   python-discovery
     #   tox
@@ -76,7 +76,7 @@ pylint-plugin-utils==0.9.0
     #   -r requirements/base.txt
     #   pylint-celery
     #   pylint-django
-python-discovery==1.1.0
+python-discovery==1.2.0
     # via virtualenv
 python-slugify==8.0.4
     # via
@@ -108,5 +108,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.2
     # via -r requirements/dev.in
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -24,5 +24,5 @@ wheel==0.46.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==26.0.1
     # via pip-tools
-setuptools==82.0.0
+setuptools==82.0.1
     # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,11 +18,11 @@ click==8.3.1
     #   code-annotations
 click-log==0.4.0
     # via -r requirements/dev.txt
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
-coverage==7.13.4
+coverage==7.13.5
     # via -r requirements/test.in
 dill==0.4.1
     # via
@@ -35,7 +35,7 @@ distlib==0.4.0
     # via
     #   -c edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   -r requirements/dev.txt
     #   python-discovery
@@ -98,7 +98,7 @@ pylint-plugin-utils==0.9.0
     #   pylint-django
 pytest==9.0.2
     # via -r requirements/test.in
-python-discovery==1.1.0
+python-discovery==1.2.0
     # via
     #   -r requirements/dev.txt
     #   virtualenv
@@ -134,7 +134,7 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.2
     # via -r requirements/dev.txt
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via
     #   -r requirements/dev.txt
     #   tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{312}-django{42,52}, coverage, pylint
+envlist = py{312}-django{52}, coverage, pylint
 
 [testenv]
 deps =
-    django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
Dropped django 4.2 support. Bumped dependencies

Issue: https://github.com/openedx/public-engineering/issues/458