### PR TITLE
fix: added squelch and no-pii annotation check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+6.2.0 - 2026-06-26
+~~~~~~~~~~~~~~~~~~~
+
+* Add PII safety checker for logs, print statements, exceptions, and stale ``.. no_pii:`` annotations.
+
 5.7.0 - 2025-04-21
 ~~~~~~~~~~~~~~~~~~
 

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-__version__ = "6.1.0"
+__version__ = "6.2.0"

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -533,5 +533,4 @@ pii-safe-key-patterns=user_id,course_id,thread_id,comment_id,block_id,usage_id,u
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception
 # output. Any PII sink must be inside an if-block testing this flag.
-# See: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/monitoring/README.rst
 pii-squelch-flag=SQUELCH_PII_IN_LOGS

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -528,39 +528,6 @@ pii-terms =
 # Exact identifiers that superficially match PII terms but are approved
 # as non-sensitive (surrogate keys, anonymous IDs, etc.).
 pii-safe-key-patterns =
-    user_id,
-    course_id,
-    thread_id,
-    comment_id,
-    block_id,
-    usage_id,
-    usage_key,
-    anonymous_user_id,
-    service_username,
-    email_enabled,
-    email_sent_on,
-    email_scheduled,
-    require_course_email_auth,
-    reported_content_email_notifications,
-    email_reminder_sent,
-    eligibility_email_message,
-    receipt_email_message,
-    proctoring_escalation_email,
-    email_cadence,
-    attr_full_name,
-    default_full_name,
-    attr_first_name,
-    default_first_name,
-    attr_last_name,
-    default_last_name,
-    attr_username,
-    default_username,
-    attr_email,
-    default_email,
-    skip_email_verification,
-    location,
-    _location,
-    example_full_name
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception
 # output. Any PII sink must be inside an if-block testing this flag.

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -224,6 +224,10 @@ enable=
     unrecognized-inline-option,
     useless-suppression,
 
+    # PII safety checks (edx-lint built-in)
+    pii-missing-squelch,
+    pii-invalid-no-pii-annotation,
+
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
@@ -263,6 +267,7 @@ disable=
     # These are repo-specific
     feature-toggle-needs-doc,
     illegal-waffle-usage,
+    pii-invalid-no-pii-annotation,
 
     # We want to allow developers to use f-strings for readability
     logging-fstring-interpolation,
@@ -510,3 +515,23 @@ int-import-graph=
 # Exceptions that will emit a warning when being caught. Defaults to
 # "builtins.Exception"
 overgeneral-exceptions=builtins.Exception
+
+
+[PII]
+
+# Comma-separated list of identifier substrings treated as likely PII.
+# Substring matching is used, so 'email' will match 'user_email_address'.
+pii-terms=email,secondary_email,username,password,name,full_name,first_name,last_name,phone,phone_number,birth_date,ip,ip_address,location,address,mailing_address,gender,sex,bio,biography,profile_image,image,video,token,secret,retired_username
+
+# Functions that safely transform or redact PII. PII passed through these
+# functions will not trigger warnings.
+pii-safe-functions=redact,redact_pii,mask,mask_pii,hash_pii,obfuscate,obfuscate_pii
+
+# Exact identifiers that superficially match PII terms but are approved
+# as non-sensitive (surrogate keys, anonymous IDs, etc.).
+pii-safe-key-patterns=user_id,course_id,thread_id,comment_id,block_id,usage_id,usage_key,anonymous_user_id
+
+# Name of the feature toggle that guards PII-inclusive log/print/exception
+# output. Any PII sink must be inside an if-block testing this flag.
+# See: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/monitoring/README.rst
+pii-squelch-flag=SQUELCH_PII_IN_LOGS

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -521,7 +521,26 @@ overgeneral-exceptions=builtins.Exception
 
 # Comma-separated list of identifier substrings treated as likely PII.
 # Substring matching is used, so 'email' will match 'user_email_address'.
-pii-terms=email,secondary_email,username,retired_username,password,full_name,first_name,last_name,phone,phone_number,birth_date,ip_address,location,address,mailing_address,gender,profile_image,job_title,social_link
+pii-terms=
+    email,
+    secondary_email,
+    username,
+    retired_username,
+    password,
+    full_name,
+    first_name,
+    last_name,
+    phone,
+    phone_number,
+    birth_date,
+    ip_address,
+    location,
+    address,
+    mailing_address,
+    gender,
+    profile_image,
+    job_title,
+    social_link
 
 # Functions that safely transform or redact PII. PII passed through these
 # functions will not trigger warnings.
@@ -529,7 +548,40 @@ pii-safe-functions=redact,redact_pii,mask,mask_pii,hash_pii,obfuscate,obfuscate_
 
 # Exact identifiers that superficially match PII terms but are approved
 # as non-sensitive (surrogate keys, anonymous IDs, etc.).
-pii-safe-key-patterns=user_id,course_id,thread_id,comment_id,block_id,usage_id,usage_key,anonymous_user_id,service_username,email_enabled,email_sent_on,email_scheduled,require_course_email_auth,reported_content_email_notifications,email_reminder_sent,eligibility_email_message,receipt_email_message,proctoring_escalation_email,email_cadence,attr_full_name,default_full_name,attr_first_name,default_first_name,attr_last_name,default_last_name,attr_username,default_username,attr_email,default_email,skip_email_verification,location,_location,example_full_name
+pii-safe-key-patterns=
+    user_id,
+    course_id,
+    thread_id,
+    comment_id,
+    block_id,
+    usage_id,
+    usage_key,
+    anonymous_user_id,
+    service_username,
+    email_enabled,
+    email_sent_on,
+    email_scheduled,
+    require_course_email_auth,
+    reported_content_email_notifications,
+    email_reminder_sent,
+    eligibility_email_message,
+    receipt_email_message,
+    proctoring_escalation_email,
+    email_cadence,
+    attr_full_name,
+    default_full_name,
+    attr_first_name,
+    default_first_name,
+    attr_last_name,
+    default_last_name,
+    attr_username,
+    default_username,
+    attr_email,
+    default_email,
+    skip_email_verification,
+    location,
+    _location,
+    example_full_name
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception
 # output. Any PII sink must be inside an if-block testing this flag.

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -224,8 +224,9 @@ enable=
     unrecognized-inline-option,
     useless-suppression,
 
-    # PII safety check (edx-lint built-in)
+    # PII safety checks (edx-lint built-in)
     pii-missing-squelch,
+    pii-invalid-no-pii-annotation,
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
@@ -266,7 +267,6 @@ disable=
     # These are repo-specific
     feature-toggle-needs-doc,
     illegal-waffle-usage,
-    pii-invalid-no-pii-annotation,
 
     # We want to allow developers to use f-strings for readability
     logging-fstring-interpolation,
@@ -523,22 +523,10 @@ overgeneral-exceptions=builtins.Exception
 pii-terms =
     email,
     username,
-    password,
-    full_name,
-    first_name,
-    last_name,
-    phone,
-    birth_date,
-    ip_address,
-    location,
-    address,
-    gender,
-    profile_image,
-    job_title,
-    social_link
+    password
 
 # Exact identifiers that superficially match PII terms but are approved
-# as non-sensitive (surrogate keys, flag fields, system fields).
+# as non-sensitive (surrogate keys, anonymous IDs, etc.).
 pii-safe-key-patterns =
     user_id,
     course_id,
@@ -570,6 +558,8 @@ pii-safe-key-patterns =
     attr_email,
     default_email,
     skip_email_verification,
+    location,
+    _location,
     example_full_name
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -542,17 +542,6 @@ pii-terms =
     job_title,
     social_link
 
-# Functions that safely transform or redact PII. PII passed through these
-# functions will not trigger warnings.
-pii-safe-functions =
-    redact,
-    redact_pii,
-    mask,
-    mask_pii,
-    hash_pii,
-    obfuscate,
-    obfuscate_pii
-
 # Exact identifiers that superficially match PII terms but are approved
 # as non-sensitive (surrogate keys, anonymous IDs, etc.).
 pii-safe-key-patterns =

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -224,9 +224,8 @@ enable=
     unrecognized-inline-option,
     useless-suppression,
 
-    # PII safety checks (edx-lint built-in)
+    # PII safety check (edx-lint built-in)
     pii-missing-squelch,
-    pii-invalid-no-pii-annotation,
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
@@ -534,7 +533,6 @@ pii-terms =
     phone_number,
     birth_date,
     ip_address,
-    location,
     address,
     mailing_address,
     gender,
@@ -543,7 +541,7 @@ pii-terms =
     social_link
 
 # Exact identifiers that superficially match PII terms but are approved
-# as non-sensitive (surrogate keys, anonymous IDs, etc.).
+# as non-sensitive (surrogate keys, flag fields, system fields).
 pii-safe-key-patterns =
     user_id,
     course_id,

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -529,7 +529,7 @@ pii-safe-functions=redact,redact_pii,mask,mask_pii,hash_pii,obfuscate,obfuscate_
 
 # Exact identifiers that superficially match PII terms but are approved
 # as non-sensitive (surrogate keys, anonymous IDs, etc.).
-pii-safe-key-patterns=user_id,course_id,thread_id,comment_id,block_id,usage_id,usage_key,anonymous_user_id
+pii-safe-key-patterns=user_id,course_id,thread_id,comment_id,block_id,usage_id,usage_key,anonymous_user_id,service_username,email_enabled,email_sent_on,email_scheduled,require_course_email_auth,reported_content_email_notifications,email_reminder_sent,eligibility_email_message,receipt_email_message,attr_full_name,default_full_name,attr_first_name,default_first_name,attr_last_name,default_last_name,attr_username,default_username,attr_email,default_email,skip_email_verification,location,example_full_name
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception
 # output. Any PII sink must be inside an if-block testing this flag.

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -522,19 +522,16 @@ overgeneral-exceptions=builtins.Exception
 # Substring matching is used, so 'email' will match 'user_email_address'.
 pii-terms =
     email,
-    secondary_email,
     username,
-    retired_username,
     password,
     full_name,
     first_name,
     last_name,
     phone,
-    phone_number,
     birth_date,
     ip_address,
+    location,
     address,
-    mailing_address,
     gender,
     profile_image,
     job_title,
@@ -573,8 +570,6 @@ pii-safe-key-patterns =
     attr_email,
     default_email,
     skip_email_verification,
-    location,
-    _location,
     example_full_name
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -521,7 +521,7 @@ overgeneral-exceptions=builtins.Exception
 
 # Comma-separated list of identifier substrings treated as likely PII.
 # Substring matching is used, so 'email' will match 'user_email_address'.
-pii-terms=
+pii-terms =
     email,
     secondary_email,
     username,
@@ -544,11 +544,18 @@ pii-terms=
 
 # Functions that safely transform or redact PII. PII passed through these
 # functions will not trigger warnings.
-pii-safe-functions=redact,redact_pii,mask,mask_pii,hash_pii,obfuscate,obfuscate_pii
+pii-safe-functions =
+    redact,
+    redact_pii,
+    mask,
+    mask_pii,
+    hash_pii,
+    obfuscate,
+    obfuscate_pii
 
 # Exact identifiers that superficially match PII terms but are approved
 # as non-sensitive (surrogate keys, anonymous IDs, etc.).
-pii-safe-key-patterns=
+pii-safe-key-patterns =
     user_id,
     course_id,
     thread_id,
@@ -585,4 +592,4 @@ pii-safe-key-patterns=
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception
 # output. Any PII sink must be inside an if-block testing this flag.
-pii-squelch-flag=SQUELCH_PII_IN_LOGS
+pii-squelch-flag = SQUELCH_PII_IN_LOGS

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -521,7 +521,7 @@ overgeneral-exceptions=builtins.Exception
 
 # Comma-separated list of identifier substrings treated as likely PII.
 # Substring matching is used, so 'email' will match 'user_email_address'.
-pii-terms=email,secondary_email,username,password,name,full_name,first_name,last_name,phone,phone_number,birth_date,ip,ip_address,location,address,mailing_address,gender,sex,bio,biography,profile_image,image,video,token,secret,retired_username
+pii-terms=email,secondary_email,username,retired_username,password,full_name,first_name,last_name,phone,phone_number,birth_date,ip_address,location,address,mailing_address,gender,profile_image,job_title,social_link
 
 # Functions that safely transform or redact PII. PII passed through these
 # functions will not trigger warnings.

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -529,7 +529,7 @@ pii-safe-functions=redact,redact_pii,mask,mask_pii,hash_pii,obfuscate,obfuscate_
 
 # Exact identifiers that superficially match PII terms but are approved
 # as non-sensitive (surrogate keys, anonymous IDs, etc.).
-pii-safe-key-patterns=user_id,course_id,thread_id,comment_id,block_id,usage_id,usage_key,anonymous_user_id,service_username,email_enabled,email_sent_on,email_scheduled,require_course_email_auth,reported_content_email_notifications,email_reminder_sent,eligibility_email_message,receipt_email_message,attr_full_name,default_full_name,attr_first_name,default_first_name,attr_last_name,default_last_name,attr_username,default_username,attr_email,default_email,skip_email_verification,location,example_full_name
+pii-safe-key-patterns=user_id,course_id,thread_id,comment_id,block_id,usage_id,usage_key,anonymous_user_id,service_username,email_enabled,email_sent_on,email_scheduled,require_course_email_auth,reported_content_email_notifications,email_reminder_sent,eligibility_email_message,receipt_email_message,proctoring_escalation_email,email_cadence,attr_full_name,default_full_name,attr_first_name,default_first_name,attr_last_name,default_last_name,attr_username,default_username,attr_email,default_email,skip_email_verification,location,_location,example_full_name
 
 # Name of the feature toggle that guards PII-inclusive log/print/exception
 # output. Any PII sink must be inside an if-block testing this flag.

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -27,19 +27,7 @@ class PiiConfigMixin:
         cfg = self.linter.config
         raw_terms = getattr(cfg, "pii_terms", ["email", "username", "password"])
         self._pii_terms_cache = [t.strip().lower() for t in raw_terms if t.strip()]
-        raw_keys = getattr(cfg, "pii_safe_key_patterns", [
-            "user_id", "course_id", "thread_id", "comment_id",
-            "block_id", "usage_id", "usage_key", "anonymous_user_id",
-            "service_username",
-            "email_enabled", "email_sent_on", "email_scheduled",
-            "require_course_email_auth", "reported_content_email_notifications",
-            "email_reminder_sent", "eligibility_email_message", "receipt_email_message",
-            "proctoring_escalation_email", "email_cadence",
-            "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
-            "attr_last_name", "default_last_name", "attr_username", "default_username",
-            "attr_email", "default_email", "skip_email_verification",
-            "location", "_location", "example_full_name",
-        ])
+        raw_keys = getattr(cfg, "pii_safe_key_patterns", [])
         self._safe_keys_cache = {k.strip().lower() for k in raw_keys if k.strip()}
 
     def _pii_terms(self):

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -1,181 +1,46 @@
 """
-Shared PII checker infrastructure: constants, option defaults, and helpers.
+Shared PII name-matching helpers for the PII pylint checkers.
 
-- ``PiiOptionsChecker``: registers all [PII] pylint options once so both
-  checkers can read them from ``linter.config`` without ordering constraints.
-- ``PiiConfigMixin``: mixin with cached config access and all PII-detection
-  helpers shared by ``PiiMissingSquelchChecker`` and ``PiiAnnotationChecker``.
+Contains only code shared by both pii_squelch_check (W7630) and
+pii_annotation_check (W7633). Checker-specific logic lives in each
+checker's own module.
 """
 
-import re
 
-from astroid import exceptions as astroid_exceptions
-from astroid import nodes as astroid_nodes
-from pylint.checkers import BaseChecker
-
-from .common import check_visitors
-
-
-# Logging method names treated as output sinks.
-_LOG_METHODS = frozenset({
-    "debug", "info", "warning", "warn", "error",
-    "critical", "exception", "log",
-})
-
-# Regexes for ``.. no_pii:`` in docstrings and inline comments.
-_NO_PII_DOCSTRING_RE = re.compile(r"\.\.\s*no_pii", re.IGNORECASE)
-_NO_PII_COMMENT_RE = re.compile(r"[\s]*#[\s]*\.\.\s*no_pii", re.IGNORECASE)
-
-# Lines above ``class`` to scan for a comment-style annotation.
-_ANNOTATION_LOOKAHEAD = 10
-
-# Default squelch feature-flag name.
-_DEFAULT_SQUELCH_FLAG = "SQUELCH_PII_IN_LOGS"
-
-# OEP-0030 PII identifier substrings — substring-matched against variable names.
-_DEFAULT_PII_TERMS = [
-    "email",
-    "username",
-    "password",
-    "full_name", "first_name", "last_name",
-    "phone",
-    "birth_date",
-    "ip_address",
-    "location",
-    "address",
-    "gender",
-    "profile_image",
-    "job_title",
-    "social_link",
-]
-
-# Exact-match safe keys: identifiers that look like PII but are not sensitive.
-_DEFAULT_SAFE_KEYS = [
-    "user_id", "course_id", "thread_id", "comment_id",
-    "block_id", "usage_id", "usage_key", "anonymous_user_id",
-    "service_username",
-    "email_enabled", "email_sent_on", "email_scheduled",
-    "require_course_email_auth", "reported_content_email_notifications",
-    "email_reminder_sent", "eligibility_email_message", "receipt_email_message",
-    "proctoring_escalation_email", "email_cadence",
-    "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
-    "attr_last_name", "default_last_name", "attr_username", "default_username",
-    "attr_email", "default_email", "skip_email_verification",
-    "example_full_name",
-]
-
-
-# PiiOptionsChecker — owns all [PII] option declarations.
-@check_visitors
-class PiiOptionsChecker(BaseChecker):
-    """
-    Registers the shared [PII] pylint options (pii-terms, pii-safe-key-patterns,
-    pii-squelch-flag, pii-django-model-bases) so they appear in ``linter.config``
-    before any checker reads them.  No messages or visitors — options only.
-    """
-
-    name = "pii-options"
-
-    options = (
-        (
-            "pii-terms",
-            {
-                "default": ", ".join(_DEFAULT_PII_TERMS),
-                "type": "csv",
-                "metavar": "<comma-separated PII terms>",
-                "help": (
-                    "Comma-separated OEP-0030 PII identifier substrings matched against "
-                    "variable names and attribute accesses passed to log/print/exception "
-                    "sinks.  String literals are NOT matched."
-                ),
-            },
-        ),
-        (
-            "pii-safe-key-patterns",
-            {
-                "default": ", ".join(_DEFAULT_SAFE_KEYS),
-                "type": "csv",
-                "metavar": "<comma-separated safe key patterns>",
-                "help": (
-                    "Exact identifiers that look like PII terms but are approved as "
-                    "non-sensitive (e.g. surrogate keys, flag fields). Exact match only."
-                ),
-            },
-        ),
-        (
-            "pii-squelch-flag",
-            {
-                "default": _DEFAULT_SQUELCH_FLAG,
-                "type": "string",
-                "metavar": "<flag name>",
-                "help": (
-                    "Name of the feature toggle that gates PII-inclusive output. "
-                    "PII sinks must be inside an if-block testing this flag. "
-                    "Default: SQUELCH_PII_IN_LOGS."
-                ),
-            },
-        ),
-        (
-            "pii-django-model-bases",
-            {
-                "default": "Model",
-                "type": "csv",
-                "metavar": "<comma-separated base class names>",
-                "help": (
-                    "Base class names that identify a Django model. "
-                    "Both PII checkers only fire inside non-abstract, non-proxy "
-                    "subclasses of these bases. Default: Model."
-                ),
-            },
-        ),
-    )
-
-
-def register_checkers(linter):
-    """
-    Register the PII options provider.
-    """
-    linter.register_checker(PiiOptionsChecker(linter))
-
-
-# PiiConfigMixin — shared config access and PII-detection helpers.
 class PiiConfigMixin:
     """
-    Mixin providing cached config reads and all PII-detection helpers.
+    Mixin providing cached access to pii-terms and safe-key config options.
+
+    Used by both PiiMissingSquelchChecker (W7630) and PiiAnnotationChecker (W7633).
+    Each checker calls _init_pii_caches() in visit_module to reset per-module state.
     """
 
     def _init_pii_caches(self):
-        """
-        Reset per-module config cache slots to ``None`` (call from visit_module).
-        """
+        """Reset per-module config caches to None."""
         self._pii_terms_cache = None
         self._safe_keys_cache = None
-        self._django_model_bases_cache = None
 
     def _ensure_config_cached(self):
-        """
-        Populate config caches from linter.config on the first call per module.
-        """
+        """Populate pii-terms and safe-key caches on first call within a module."""
         if self._pii_terms_cache is not None:
             return
-
         cfg = self.linter.config
-
-        self._pii_terms_cache = [
-            term.strip().lower()
-            for term in getattr(cfg, "pii_terms", _DEFAULT_PII_TERMS)
-            if term.strip()
-        ]
-        self._safe_keys_cache = {
-            key.strip().lower()
-            for key in getattr(cfg, "pii_safe_key_patterns", _DEFAULT_SAFE_KEYS)
-            if key.strip()
-        }
-        self._django_model_bases_cache = {
-            base.strip()
-            for base in getattr(cfg, "pii_django_model_bases", ["Model"])
-            if base.strip()
-        }
+        raw_terms = getattr(cfg, "pii_terms", ["email", "username", "password"])
+        self._pii_terms_cache = [t.strip().lower() for t in raw_terms if t.strip()]
+        raw_keys = getattr(cfg, "pii_safe_key_patterns", [
+            "user_id", "course_id", "thread_id", "comment_id",
+            "block_id", "usage_id", "usage_key", "anonymous_user_id",
+            "service_username",
+            "email_enabled", "email_sent_on", "email_scheduled",
+            "require_course_email_auth", "reported_content_email_notifications",
+            "email_reminder_sent", "eligibility_email_message", "receipt_email_message",
+            "proctoring_escalation_email", "email_cadence",
+            "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
+            "attr_last_name", "default_last_name", "attr_username", "default_username",
+            "attr_email", "default_email", "skip_email_verification",
+            "location", "_location", "example_full_name",
+        ])
+        self._safe_keys_cache = {k.strip().lower() for k in raw_keys if k.strip()}
 
     def _pii_terms(self):
         self._ensure_config_cached()
@@ -185,306 +50,14 @@ class PiiConfigMixin:
         self._ensure_config_cached()
         return self._safe_keys_cache
 
-    def _squelch_flag(self):
-        return getattr(self.linter.config, "pii_squelch_flag", _DEFAULT_SQUELCH_FLAG)
-
-    def _is_inside_squelch_guard(self, node):
-        """
-        Return True if *node* is nested inside an ``if`` block that tests the
-        configured squelch flag.  Recognised patterns:
-
-        1. ``if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):``
-        2. ``if settings.SQUELCH_PII_IN_LOGS:``
-        3. ``if settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):``
-        4. ``if settings.FEATURES['SQUELCH_PII_IN_LOGS']:``
-        5. ``if SQUELCH_PII_IN_LOGS.is_enabled():``
-        6. ``if SQUELCH_PII_IN_LOGS:``
-        7. ``if not SQUELCH_PII_IN_LOGS:``
-        8. ``if not SQUELCH_PII_IN_LOGS.is_active():``
-        """
-        flag = self._squelch_flag()
-        current = node.parent
-        while current is not None:
-            if isinstance(current, astroid_nodes.Module):
-                break
-            if isinstance(current, astroid_nodes.If):
-                if self._test_references_flag(current.test, flag):
-                    return True
-            current = current.parent
-        return False
-
-    def _test_references_flag(self, test, flag):
-        """
-        Return True if AST node *test* references the squelch *flag*.
-        """
-        # Pattern 1: if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
-        if isinstance(test, astroid_nodes.Call):
-            func = test.func
-            if (
-                isinstance(func, astroid_nodes.Name)
-                and func.name == "getattr"
-                and len(test.args) >= 2
-            ):
-                second_arg = test.args[1]
-                if isinstance(second_arg, astroid_nodes.Const) and second_arg.value == flag:
-                    return True
-
-        # Pattern 2: if settings.SQUELCH_PII_IN_LOGS
-        if isinstance(test, astroid_nodes.Attribute) and test.attrname == flag:
-            return True
-
-        # Pattern 3: if settings.FEATURES.get('SQUELCH_PII_IN_LOGS')
-        if isinstance(test, astroid_nodes.Call) and isinstance(test.func, astroid_nodes.Attribute):
-            if test.func.attrname == "get" and test.args:
-                first_arg = test.args[0]
-                if isinstance(first_arg, astroid_nodes.Const) and first_arg.value == flag:
-                    return True
-
-        # Pattern 4: if settings.FEATURES['SQUELCH_PII_IN_LOGS']
-        if isinstance(test, astroid_nodes.Subscript):
-            slc = test.slice
-            _IndexNode = getattr(astroid_nodes, "Index", None)
-            if _IndexNode is not None and isinstance(slc, _IndexNode):  # pylint: disable=isinstance-second-argument-not-valid-type
-                slc = slc.value
-            if isinstance(slc, astroid_nodes.Const) and slc.value == flag:
-                return True
-
-        # Pattern 5: if SQUELCH_PII_IN_LOGS.is_enabled()
-        if isinstance(test, astroid_nodes.Call) and isinstance(test.func, astroid_nodes.Attribute):
-            if test.func.attrname in ("is_enabled", "is_waffle_flag_active"):
-                if self._test_references_flag(test.func.expr, flag):
-                    return True
-
-        # Pattern 6: if SQUELCH_PII_IN_LOGS
-        if isinstance(test, astroid_nodes.Name) and test.name == flag:
-            return True
-
-        # Pattern 7 & 8: negated forms
-        if isinstance(test, astroid_nodes.UnaryOp) and test.op == "not":
-            return self._test_references_flag(test.operand, flag)
-
-        # Backward-compatible method-call forms that still reference the flag.
-        if isinstance(test, astroid_nodes.Call) and isinstance(test.func, astroid_nodes.Attribute):
-            if test.func.attrname in ("is_active",):
-                if self._test_references_flag(test.func.expr, flag):
-                    return True
-
-        return False
-
-    def _contains_pii(self, node):
-        """
-        Recursively inspect *node*; return the first PII term found, or None.
-        Checks Name, Attribute, f-strings, binary ops, dicts, and nested calls.
-        String literals are NOT checked.
-        """
-        match node:
-            case None:
-                return None
-
-            # A plain name: check it directly.
-            case astroid_nodes.Name():
-                if self._is_pii_name(node.name):
-                    return node.name
-
-            # An attribute access (e.g. user.email, request.user.username).
-            case astroid_nodes.Attribute():
-                if self._is_pii_name(node.attrname):
-                    return node.attrname
-
-            # A call: recurse into args and keyword values.
-            case astroid_nodes.Call():
-                for arg in node.args:
-                    found = self._contains_pii(arg)
-                    if found:
-                        return found
-                for kw in node.keywords or []:
-                    found = self._contains_pii(kw.value)
-                    if found:
-                        return found
-
-            # f-string: recurse into each formatted value.
-            case astroid_nodes.JoinedStr():
-                for value in node.values:
-                    if isinstance(value, astroid_nodes.FormattedValue):
-                        found = self._contains_pii(value.value)
-                        if found:
-                            return found
-
-            # Binary operation (e.g. "hello " + username  or  "email: %s" % email).
-            case astroid_nodes.BinOp():
-                return self._contains_pii(node.left) or self._contains_pii(node.right)
-
-            # Tuple / List / Set: recurse into each element.
-            case astroid_nodes.Tuple() | astroid_nodes.List() | astroid_nodes.Set():
-                for elt in node.elts:
-                    found = self._contains_pii(elt)
-                    if found:
-                        return found
-
-            # Dict: recurse into values (keys are usually string identifiers).
-            case astroid_nodes.Dict():
-                for _key, value in node.items:
-                    found = self._contains_pii(value)
-                    if found:
-                        return found
-
-        return None
-
     def _is_pii_name(self, name):
         """
         Return True if *name* is a likely PII identifier.
 
-        Safe-key exact match takes priority; then substring match against pii-terms.
+        - Exact match against pii-safe-key-patterns → not PII.
+        - Substring match of any pii-term inside *name* → PII.
         """
         lower = name.lower()
         if lower in self._safe_keys():
             return False
-        for term in self._pii_terms():
-            if term in lower:
-                return True
-        return False
-
-    def _is_annotation_eligible_django_model(self, node):
-        """
-        Return True if *node* is a concrete (non-abstract, non-proxy) Django model.
-        """
-        self._ensure_config_cached()
-        model_bases = self._django_model_bases_cache
-
-        # Try astroid's resolved ancestor walk first (works when Django is importable).
-        is_model_subclass = False
-        try:
-            for ancestor in node.ancestors():
-                if ancestor.name in model_bases:
-                    is_model_subclass = True
-                    break
-        except astroid_exceptions.AstroidError:
-            # Ancestor inference failed; fallback to raw AST base-name walk below.
-            pass
-
-        # Fallback: walk raw AST base names for standalone pylint runs.
-        if not is_model_subclass:
-            is_model_subclass = self._raw_ast_is_model_subclass(node)
-
-        if not is_model_subclass:
-            return False
-
-        # Skip abstract and proxy models (checked via inner Meta class).
-        if any(self._meta_has_true_flag(node, flag) for flag in ("abstract", "proxy")):
-            return False
-
-        return True
-
-    def _raw_ast_is_model_subclass(self, node):
-        """
-        Return True if *node* inherits from a model base using raw AST names (BFS).
-        """
-        model_bases = self._django_model_bases_cache
-        visited = set()
-        queue = list(self._direct_base_names(node))
-        while queue:
-            name = queue.pop(0)
-            if name in visited:
-                continue
-            visited.add(name)
-            if name in model_bases:
-                return True
-            parent_node = self._module_classdefs.get(name)
-            if parent_node is not None:
-                queue.extend(self._direct_base_names(parent_node))
-        return False
-
-    @staticmethod
-    def _direct_base_names(classdef_node):
-        """
-        Yield the simple name of each direct base class in *classdef_node*.
-        """
-        for base in classdef_node.bases:
-            if isinstance(base, astroid_nodes.Name):
-                yield base.name
-            elif isinstance(base, astroid_nodes.Attribute):
-                yield base.attrname
-
-    @staticmethod
-    def _meta_has_true_flag(classdef_node, flag_name):
-        """
-        Return True if the inner ``Meta`` class sets *flag_name* = True.
-        """
-        for child in classdef_node.body:
-            if not (
-                isinstance(child, astroid_nodes.ClassDef)
-                and child.name == "Meta"
-            ):
-                continue
-            for stmt in child.body:
-                if not isinstance(stmt, astroid_nodes.Assign):
-                    continue
-                for target in stmt.targets:
-                    if (
-                        isinstance(target, astroid_nodes.AssignName)
-                        and target.name == flag_name
-                        and isinstance(stmt.value, astroid_nodes.Const)
-                        and stmt.value.value is True
-                    ):
-                        return True
-        return False
-
-    def _class_has_no_pii_annotation(self, node):
-        """
-        Return True if *node* has a ``.. no_pii:`` annotation (docstring or comment).
-        """
-        return self._docstring_has_no_pii(node) or self._comment_has_no_pii(node)
-
-    def _docstring_has_no_pii(self, node):
-        """
-        Return True if the class docstring contains ``.. no_pii:``.
-        """
-        docstring = node.doc_node.value if node.doc_node else ""
-        return bool(_NO_PII_DOCSTRING_RE.search(docstring))
-
-    def _comment_has_no_pii(self, node):
-        """
-        Return True if a comment annotation appears above the class.
-        """
-        if not self._source_lines:
-            return False
-        # node.lineno is 1-indexed; convert to 0-indexed for list access.
-        end = node.lineno - 1       # exclusive (the ``class`` line itself)
-        start = max(0, end - _ANNOTATION_LOOKAHEAD)
-        for line in self._source_lines[start:end]:
-            if _NO_PII_COMMENT_RE.match(line):
-                return True
-        return False
-
-    def _collect_pii_fields(self, node):
-        """
-        Return all PII-like field names found in the class body.
-        """
-        found = []
-        for child in node.body:
-            # simple assignment: email = models.EmailField()
-            if isinstance(child, astroid_nodes.Assign):
-                for target in child.targets:
-                    if isinstance(target, astroid_nodes.AssignName):
-                        if self._is_pii_name(target.name):
-                            found.append(target.name)
-
-            # annotated assignment: email: str = ""
-            elif isinstance(child, astroid_nodes.AnnAssign):
-                if isinstance(child.target, astroid_nodes.AssignName):
-                    if self._is_pii_name(child.target.name):
-                        found.append(child.target.name)
-
-            # instance attributes set inside methods: self.email = ...
-            elif isinstance(child, astroid_nodes.FunctionDef):
-                for stmt in child.nodes_of_class(astroid_nodes.Assign):
-                    for target in stmt.targets:
-                        if (
-                            isinstance(target, astroid_nodes.AssignAttr)
-                            and isinstance(target.expr, astroid_nodes.Name)
-                            and target.expr.name == "self"
-                            and self._is_pii_name(target.attrname)
-                        ):
-                            found.append(f"self.{target.attrname}")
-
-        return found
+        return any(term in lower for term in self._pii_terms())

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -109,6 +109,14 @@ class PiiConfigMixin:
         raw_keys = getattr(cfg, "pii_safe_key_patterns", [
             "user_id", "course_id", "thread_id", "comment_id",
             "block_id", "usage_id", "usage_key", "anonymous_user_id",
+            "service_username",
+            "email_enabled", "email_sent_on", "email_scheduled",
+            "require_course_email_auth", "reported_content_email_notifications",
+            "email_reminder_sent", "eligibility_email_message", "receipt_email_message",
+            "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
+            "attr_last_name", "default_last_name", "attr_username", "default_username",
+            "attr_email", "default_email", "skip_email_verification",
+            "location", "example_full_name"
         ])
         self._safe_keys_cache = {k.strip().lower() for k in raw_keys if k.strip()}
 

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -65,13 +65,13 @@ class PiiConfigMixin:
             "job_title",
             "social_link",
         ])
-        self._pii_terms_cache = [t.strip().lower() for t in raw_terms if t.strip()]
+        self._pii_terms_cache = [term.strip().lower() for term in raw_terms if term.strip()]
 
         raw_fns = getattr(
             cfg, "pii_safe_functions",
             ["redact", "redact_pii", "mask", "mask_pii", "hash_pii", "obfuscate", "obfuscate_pii"],
         )
-        self._safe_functions_cache = {f.strip() for f in raw_fns if f.strip()}
+        self._safe_functions_cache = {func_name.strip() for func_name in raw_fns if func_name.strip()}
 
         raw_keys = getattr(cfg, "pii_safe_key_patterns", [
             "user_id", "course_id", "thread_id", "comment_id",
@@ -86,10 +86,10 @@ class PiiConfigMixin:
             "attr_email", "default_email", "skip_email_verification",
             "location", "_location", "example_full_name"
         ])
-        self._safe_keys_cache = {k.strip().lower() for k in raw_keys if k.strip()}
+        self._safe_keys_cache = {key.strip().lower() for key in raw_keys if key.strip()}
 
         raw_bases = getattr(cfg, "pii_django_model_bases", ["Model"])
-        self._django_model_bases_cache = {b.strip() for b in raw_bases if b.strip()}
+        self._django_model_bases_cache = {base.strip() for base in raw_bases if base.strip()}
 
     def _pii_terms(self):
         self._ensure_config_cached()

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -1,0 +1,494 @@
+"""
+Shared constants and helpers for the PII pylint checkers.
+
+This module is an *internal* library — it is not a checker and has no
+``register_checkers`` entry point.  It is imported by:
+
+* :mod:`edx_lint.pylint.pii_squelch_check`  — the missing-squelch checker
+* :mod:`edx_lint.pylint.pii_annotation_check` — the annotation checker
+
+Contents
+--------
+* Module-level constants (``_LOG_METHODS``, regexes, look-ahead distance,
+  default squelch-flag name).
+* :class:`PiiConfigMixin` — a mixin that provides cached access to pylint
+  config options and all shared helper methods (PII-name matching,
+  SQUELCH guard detection, Django model eligibility, annotation detection,
+  field scanning).
+
+Both concrete checker classes inherit from this mixin so that every helper
+is implemented exactly once.
+"""
+
+import re
+
+from astroid import nodes as astroid_nodes
+
+
+# ---------------------------------------------------------------------------
+# Logging method names that are treated as output sinks.
+# ---------------------------------------------------------------------------
+_LOG_METHODS = frozenset({
+    "debug", "info", "warning", "warn", "error",
+    "critical", "exception", "log",
+})
+
+# ---------------------------------------------------------------------------
+# Regex patterns used to detect ``.. no_pii:`` in docstrings / comments.
+# ---------------------------------------------------------------------------
+_NO_PII_DOCSTRING_RE = re.compile(r"\.\.\s*no_pii", re.IGNORECASE)
+_NO_PII_COMMENT_RE = re.compile(r"[\s]*#[\s]*\.\.\s*no_pii", re.IGNORECASE)
+
+# How many lines *above* the ``class`` keyword to search for a comment annotation.
+_ANNOTATION_LOOKAHEAD = 5
+
+# Default name of the squelch feature flag.
+_DEFAULT_SQUELCH_FLAG = "SQUELCH_PII_IN_LOGS"
+
+
+class PiiConfigMixin:
+    """Mixin that provides cached access to PII-related pylint config options.
+
+    Both :class:`~edx_lint.pylint.pii_squelch_check.PiiMissingSquelchChecker`
+    and :class:`~edx_lint.pylint.pii_annotation_check.PiiAnnotationChecker`
+    inherit from this mixin.
+
+    All options (``pii-terms``, ``pii-safe-functions``, etc.) are defined
+    on ``PiiMissingSquelchChecker``.  The annotation checker reads those
+    values from ``self.linter.config`` via ``getattr`` with safe defaults, so
+    it works correctly whether or not the squelch checker is also loaded.
+    """
+
+    # ------------------------------------------------------------------
+    # Initialisation helpers (call from __init__ of each concrete checker)
+    # ------------------------------------------------------------------
+
+    def _init_pii_caches(self):
+        """Initialise the per-module config cache slots to ``None``."""
+        self._pii_terms_cache = None
+        self._safe_functions_cache = None
+        self._safe_keys_cache = None
+        self._django_model_bases_cache = None
+
+    # ------------------------------------------------------------------
+    # Cached config helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_config_cached(self):
+        """Populate the config caches on the first call within a module.
+
+        Reads option values from ``self.linter.config`` using ``getattr``
+        with sensible defaults so that each checker is independently usable
+        even if the other checker (and its options) is not loaded.
+        """
+        if self._pii_terms_cache is not None:
+            return
+
+        cfg = self.linter.config
+
+        raw_terms = getattr(cfg, "pii_terms", [
+            "email", "secondary_email",
+            "username", "retired_username",
+            "password",
+            "name", "full_name", "first_name", "last_name",
+            "phone", "phone_number",
+            "birth_date",
+            "ip", "ip_address",
+            "location", "address", "mailing_address",
+            "gender", "sex",
+            "bio", "biography",
+            "profile_image", "image", "video",
+            "title", "job_title",
+            "social", "website",
+        ])
+        self._pii_terms_cache = [t.strip().lower() for t in raw_terms if t.strip()]
+
+        raw_fns = getattr(
+            cfg, "pii_safe_functions",
+            ["redact", "redact_pii", "mask", "mask_pii", "hash_pii", "obfuscate", "obfuscate_pii"],
+        )
+        self._safe_functions_cache = {f.strip() for f in raw_fns if f.strip()}
+
+        raw_keys = getattr(cfg, "pii_safe_key_patterns", [
+            "user_id", "course_id", "thread_id", "comment_id",
+            "block_id", "usage_id", "usage_key", "anonymous_user_id",
+        ])
+        self._safe_keys_cache = {k.strip().lower() for k in raw_keys if k.strip()}
+
+        raw_bases = getattr(cfg, "pii_django_model_bases", ["Model"])
+        self._django_model_bases_cache = {b.strip() for b in raw_bases if b.strip()}
+
+    def _pii_terms(self):
+        self._ensure_config_cached()
+        return self._pii_terms_cache
+
+    def _safe_functions(self):
+        self._ensure_config_cached()
+        return self._safe_functions_cache
+
+    def _safe_keys(self):
+        self._ensure_config_cached()
+        return self._safe_keys_cache
+
+    def _squelch_flag(self):
+        return getattr(self.linter.config, "pii_squelch_flag", _DEFAULT_SQUELCH_FLAG)
+
+    # ------------------------------------------------------------------
+    # SQUELCH_PII_IN_LOGS guard detection
+    # ------------------------------------------------------------------
+
+    def _is_inside_squelch_guard(self, node):
+        """Walk up the AST parent chain and return True if *node* is nested
+        inside an ``if`` block that tests the configured squelch flag.
+
+        Recognised patterns (flag name is configurable via pii-squelch-flag):
+
+        1. ``if SQUELCH_PII_IN_LOGS:``
+        2. ``if not SQUELCH_PII_IN_LOGS:``
+        3. ``if settings.SQUELCH_PII_IN_LOGS:``
+        4. ``if settings.FEATURES['SQUELCH_PII_IN_LOGS']:``
+        5. ``if settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):``
+        6. ``if SQUELCH_PII_IN_LOGS.is_enabled():``
+        7. ``if not SQUELCH_PII_IN_LOGS.is_active():``
+        """
+        flag = self._squelch_flag()
+        current = node.parent
+        while current is not None:
+            if isinstance(current, astroid_nodes.Module):
+                break
+            if isinstance(current, astroid_nodes.If):
+                if self._test_references_flag(current.test, flag):
+                    return True
+            current = current.parent
+        return False
+
+    def _test_references_flag(self, test, flag):
+        """Return True if AST node *test* references the squelch *flag*."""
+        # Pattern 1: if SQUELCH_PII_IN_LOGS:
+        if isinstance(test, astroid_nodes.Name):
+            return test.name == flag
+
+        # Pattern 2: if not <X>:  — recurse into the operand
+        if isinstance(test, astroid_nodes.UnaryOp) and test.op == "not":
+            return self._test_references_flag(test.operand, flag)
+
+        # Pattern 3: if settings.SQUELCH_PII_IN_LOGS:
+        if isinstance(test, astroid_nodes.Attribute):
+            if test.attrname == flag:
+                return True
+
+        # Pattern 4: if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+        if isinstance(test, astroid_nodes.Subscript):
+            slc = test.slice
+            # astroid wraps index in an Index node in older versions
+            if hasattr(astroid_nodes, "Index") and isinstance(slc, astroid_nodes.Index):
+                slc = slc.value  # type: ignore[attr-defined]
+            if isinstance(slc, astroid_nodes.Const) and slc.value == flag:
+                return True
+
+        # Pattern 5 & 6: method calls — dict.get(flag) or flag_obj.is_enabled()
+        if isinstance(test, astroid_nodes.Call):
+            func = test.func
+            if isinstance(func, astroid_nodes.Attribute):
+                method = func.attrname
+                if method in ("get", "is_enabled", "is_active", "is_waffle_flag_active"):
+                    # dict.get('SQUELCH_PII_IN_LOGS') — check first arg
+                    if test.args:
+                        first_arg = test.args[0]
+                        if isinstance(first_arg, astroid_nodes.Const) and first_arg.value == flag:
+                            return True
+                    # flag_obj.is_enabled() — check the receiver
+                    if self._test_references_flag(func.expr, flag):
+                        return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Recursive PII detection inside AST subtrees
+    # ------------------------------------------------------------------
+
+    def _contains_pii(self, node):
+        """Recursively inspect *node* for likely PII.
+
+        Returns the first matching PII term string, or ``None``.
+
+        NOTE: String literals (Const nodes) are intentionally NOT checked.
+        A log message like ``log.info("user email: unknown")`` contains the
+        word "email" in the message text, but no actual PII value is leaking.
+        Only variable names (Name) and attribute accesses (Attribute) carry
+        real user data and are checked.  Matching Const nodes caused false
+        positives on every log message that described a PII field.
+        """
+        if node is None:
+            return None
+
+        # A plain name: check it directly.
+        if isinstance(node, astroid_nodes.Name):
+            if self._is_pii_name(node.name):
+                return node.name
+
+        # An attribute access (e.g. user.email, request.user.username).
+        elif isinstance(node, astroid_nodes.Attribute):
+            if self._is_pii_name(node.attrname):
+                return node.attrname
+
+        # A call: if it's a safe function, stop; otherwise recurse into args.
+        elif isinstance(node, astroid_nodes.Call):
+            func_name = self._call_func_name(node)
+            if func_name and func_name in self._safe_functions():
+                return None
+            for arg in node.args:
+                found = self._contains_pii(arg)
+                if found:
+                    return found
+            for kw in node.keywords or []:
+                found = self._contains_pii(kw.value)
+                if found:
+                    return found
+
+        # f-string: recurse into each formatted value.
+        elif isinstance(node, astroid_nodes.JoinedStr):
+            for value in node.values:
+                if isinstance(value, astroid_nodes.FormattedValue):
+                    found = self._contains_pii(value.value)
+                    if found:
+                        return found
+
+        # Binary operation (e.g. "hello " + username  or  "email: %s" % email).
+        elif isinstance(node, astroid_nodes.BinOp):
+            return self._contains_pii(node.left) or self._contains_pii(node.right)
+
+        # Tuple / List / Set: recurse into each element.
+        elif isinstance(node, (astroid_nodes.Tuple, astroid_nodes.List, astroid_nodes.Set)):
+            for elt in node.elts:
+                found = self._contains_pii(elt)
+                if found:
+                    return found
+
+        # Dict: recurse into values (keys are usually string identifiers).
+        elif isinstance(node, astroid_nodes.Dict):
+            for _key, value in node.items:
+                found = self._contains_pii(value)
+                if found:
+                    return found
+
+        return None
+
+    # ------------------------------------------------------------------
+    # PII name matching
+    # ------------------------------------------------------------------
+
+    def _is_pii_name(self, name):
+        """Return True if *name* is a likely PII identifier.
+
+        Rules:
+
+        - Exact match against pii-safe-key-patterns → **not** PII.
+        - Substring match of any pii-term inside *name* → PII.
+        """
+        lower = name.lower()
+        if lower in self._safe_keys():
+            return False
+        for term in self._pii_terms():
+            if term in lower:
+                return True
+        return False
+
+    @staticmethod
+    def _call_func_name(node):
+        """Return the simple function name for a Call node, or ``None``."""
+        if isinstance(node.func, astroid_nodes.Name):
+            return node.func.name
+        if isinstance(node.func, astroid_nodes.Attribute):
+            return node.func.attrname
+        return None
+
+    # ------------------------------------------------------------------
+    # Django model eligibility detection
+    # ------------------------------------------------------------------
+
+    def _is_annotation_eligible_django_model(self, node):
+        """Return True if *node* is an annotation-eligible Django model.
+
+        Replicates the exact predicate used by
+        ``code_annotations.find_django.DjangoSearch.requires_annotations()``:
+
+        1. The class must be a subclass of ``django.db.models.Model`` (detected
+           via astroid's ancestor walking when Django is importable, or via a
+           raw AST base-name BFS over the module's class definitions otherwise).
+        2. The class must **not** be abstract: its inner ``Meta`` class must not
+           contain ``abstract = True``.
+        3. The class must **not** be a proxy model: its inner ``Meta`` class must
+           not contain ``proxy = True``.
+        """
+        self._ensure_config_cached()
+        model_bases = self._django_model_bases_cache
+
+        # 1a. Try astroid's resolved ancestor walk (works when Django is on
+        #     the import path — i.e. in a real Django project lint run).
+        is_model_subclass = False
+        try:
+            for ancestor in node.ancestors():
+                if ancestor.name in model_bases:
+                    is_model_subclass = True
+                    break
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+        # 1b. Fallback: walk raw AST base names.  Handles standalone pylint
+        #     runs where Django is not importable and astroid cannot resolve
+        #     the MRO.  We do a BFS over module-level class definitions
+        #     collected in ``self._module_classdefs``.
+        if not is_model_subclass:
+            is_model_subclass = self._raw_ast_is_model_subclass(node)
+
+        if not is_model_subclass:
+            return False
+
+        # 2 & 3. Must not be abstract or proxy (checked via inner Meta class).
+        if self._meta_has_true_flag(node, "abstract"):
+            return False
+        if self._meta_has_true_flag(node, "proxy"):
+            return False
+
+        return True
+
+    def _raw_ast_is_model_subclass(self, node):
+        """Return True if *node* inherits from a known model base via raw AST names.
+
+        BFS over the module-level class definitions.  At each step checks
+        whether any direct base name matches a configured
+        ``pii-django-model-bases`` name, or a class in the same module that
+        is itself a model subclass.
+        """
+        model_bases = self._django_model_bases_cache
+        visited = set()
+        queue = list(self._direct_base_names(node))
+        while queue:
+            name = queue.pop(0)
+            if name in visited:
+                continue
+            visited.add(name)
+            if name in model_bases:
+                return True
+            parent_node = self._module_classdefs.get(name)
+            if parent_node is not None:
+                queue.extend(self._direct_base_names(parent_node))
+        return False
+
+    @staticmethod
+    def _direct_base_names(classdef_node):
+        """Yield the simple names of each direct base in *classdef_node*.
+
+        Handles two common forms:
+
+        - ``class Foo(Model):``        → ``Name(name='Model')``
+        - ``class Foo(models.Model):`` → ``Attribute(attrname='Model')``
+        """
+        for base in classdef_node.bases:
+            if isinstance(base, astroid_nodes.Name):
+                yield base.name
+            elif isinstance(base, astroid_nodes.Attribute):
+                yield base.attrname
+
+    @staticmethod
+    def _meta_has_true_flag(classdef_node, flag_name):
+        """Return True if the inner ``Meta`` class of *classdef_node* sets
+        *flag_name* to ``True``.
+
+        Looks for an assignment of the form ``<flag_name> = True`` inside a
+        nested class named ``Meta``.  This is the AST-level equivalent of
+        checking ``model._meta.abstract`` or ``model._meta.proxy`` at runtime.
+        """
+        for child in classdef_node.body:
+            if not (
+                isinstance(child, astroid_nodes.ClassDef)
+                and child.name == "Meta"
+            ):
+                continue
+            for stmt in child.body:
+                if not isinstance(stmt, astroid_nodes.Assign):
+                    continue
+                for target in stmt.targets:
+                    if (
+                        isinstance(target, astroid_nodes.AssignName)
+                        and target.name == flag_name
+                        and isinstance(stmt.value, astroid_nodes.Const)
+                        and stmt.value.value is True
+                    ):
+                        return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Class annotation detection (.. no_pii:)
+    # ------------------------------------------------------------------
+
+    def _class_has_no_pii_annotation(self, node):
+        """Return True if *node* carries a ``.. no_pii:`` annotation.
+
+        Checks two locations:
+
+        A. The class docstring (primary — edx-platform model convention).
+        B. Comment lines up to ``_ANNOTATION_LOOKAHEAD`` lines above the class
+           keyword (fallback — used in some repos).
+        """
+        return self._docstring_has_no_pii(node) or self._comment_has_no_pii(node)
+
+    def _docstring_has_no_pii(self, node):
+        """Return True if the class docstring contains ``.. no_pii:``."""
+        docstring = node.doc_node.value if node.doc_node else ""
+        return bool(_NO_PII_DOCSTRING_RE.search(docstring))
+
+    def _comment_has_no_pii(self, node):
+        """Return True if a comment annotation appears above the class."""
+        if not self._source_lines:
+            return False
+        # node.lineno is 1-indexed; convert to 0-indexed for list access.
+        end = node.lineno - 1       # exclusive (the ``class`` line itself)
+        start = max(0, end - _ANNOTATION_LOOKAHEAD)
+        for line in self._source_lines[start:end]:
+            if _NO_PII_COMMENT_RE.match(line):
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Field scanning inside a class body
+    # ------------------------------------------------------------------
+
+    def _collect_pii_fields(self, node):
+        """Return a list of PII-like field names found in the class body.
+
+        Scans three locations:
+
+        1. Class-level ``Assign`` (Django model fields, class variables).
+        2. Class-level ``AnnAssign`` (PEP 526 annotated attributes).
+        3. ``self.attr =`` assignments inside method bodies.
+        """
+        found = []
+        for child in node.body:
+            # Location 1: simple assignment  (email = models.EmailField())
+            if isinstance(child, astroid_nodes.Assign):
+                for target in child.targets:
+                    if isinstance(target, astroid_nodes.AssignName):
+                        if self._is_pii_name(target.name):
+                            found.append(target.name)
+
+            # Location 2: annotated assignment  (email: str = "")
+            elif isinstance(child, astroid_nodes.AnnAssign):
+                if isinstance(child.target, astroid_nodes.AssignName):
+                    if self._is_pii_name(child.target.name):
+                        found.append(child.target.name)
+
+            # Location 3: instance attributes inside methods
+            elif isinstance(child, astroid_nodes.FunctionDef):
+                for stmt in child.nodes_of_class(astroid_nodes.Assign):
+                    for target in stmt.targets:
+                        if (
+                            isinstance(target, astroid_nodes.AssignAttr)
+                            and isinstance(target.expr, astroid_nodes.Name)
+                            and target.expr.name == "self"
+                            and self._is_pii_name(target.attrname)
+                        ):
+                            found.append(f"self.{target.attrname}")
+
+        return found

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -37,7 +37,6 @@ class PiiConfigMixin:
     def _init_pii_caches(self):
         """Initialise the per-module config cache slots to ``None``."""
         self._pii_terms_cache = None
-        self._safe_functions_cache = None
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
 
@@ -67,12 +66,6 @@ class PiiConfigMixin:
         ])
         self._pii_terms_cache = [term.strip().lower() for term in raw_terms if term.strip()]
 
-        raw_fns = getattr(
-            cfg, "pii_safe_functions",
-            ["redact", "redact_pii", "mask", "mask_pii", "hash_pii", "obfuscate", "obfuscate_pii"],
-        )
-        self._safe_functions_cache = {func_name.strip() for func_name in raw_fns if func_name.strip()}
-
         raw_keys = getattr(cfg, "pii_safe_key_patterns", [
             "user_id", "course_id", "thread_id", "comment_id",
             "block_id", "usage_id", "usage_key", "anonymous_user_id",
@@ -94,10 +87,6 @@ class PiiConfigMixin:
     def _pii_terms(self):
         self._ensure_config_cached()
         return self._pii_terms_cache
-
-    def _safe_functions(self):
-        self._ensure_config_cached()
-        return self._safe_functions_cache
 
     def _safe_keys(self):
         self._ensure_config_cached()
@@ -208,11 +197,8 @@ class PiiConfigMixin:
             if self._is_pii_name(node.attrname):
                 return node.attrname
 
-        # A call: if it's a safe function, stop; otherwise recurse into args.
+        # A call: recurse into args and keyword values.
         elif isinstance(node, astroid_nodes.Call):
-            func_name = self._call_func_name(node)
-            if func_name and func_name in self._safe_functions():
-                return None
             for arg in node.args:
                 found = self._contains_pii(arg)
                 if found:
@@ -267,17 +253,6 @@ class PiiConfigMixin:
             if term in lower:
                 return True
         return False
-
-    @staticmethod
-    def _call_func_name(node):
-        """
-        Return the simple function name for a Call node, or ``None``.
-        """
-        if isinstance(node.func, astroid_nodes.Name):
-            return node.func.name
-        if isinstance(node.func, astroid_nodes.Attribute):
-            return node.func.attrname
-        return None
 
     # Django model eligibility detection
     def _is_annotation_eligible_django_model(self, node):

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -1,23 +1,9 @@
 """
 Shared constants and helpers for the PII pylint checkers.
 
-This module is an *internal* library — it is not a checker and has no
-``register_checkers`` entry point.  It is imported by:
-
-* :mod:`edx_lint.pylint.pii_squelch_check`  — the missing-squelch checker
-* :mod:`edx_lint.pylint.pii_annotation_check` — the annotation checker
-
-Contents
---------
-* Module-level constants (``_LOG_METHODS``, regexes, look-ahead distance,
-  default squelch-flag name).
-* :class:`PiiConfigMixin` — a mixin that provides cached access to pylint
-  config options and all shared helper methods (PII-name matching,
-  SQUELCH guard detection, Django model eligibility, annotation detection,
-  field scanning).
-
-Both concrete checker classes inherit from this mixin so that every helper
-is implemented exactly once.
+Imported by pii_squelch_check and pii_annotation_check; not a checker itself.
+Contains PiiConfigMixin, which provides cached config access and all shared
+PII-detection helpers used by both checkers.
 """
 
 import re
@@ -87,19 +73,30 @@ class PiiConfigMixin:
         cfg = self.linter.config
 
         raw_terms = getattr(cfg, "pii_terms", [
+            # email_address (OEP-0030)
             "email", "secondary_email",
+            # username (OEP-0030)
             "username", "retired_username",
+            # password (OEP-0030)
             "password",
-            "name", "full_name", "first_name", "last_name",
+            # name (OEP-0030) -- explicit compound forms only; bare 'name' excluded
+            "full_name", "first_name", "last_name",
+            # phone_number (OEP-0030)
             "phone", "phone_number",
+            # birth_date (OEP-0030)
             "birth_date",
-            "ip", "ip_address",
+            # ip (OEP-0030) -- bare 'ip' excluded (too short); ip_address only
+            "ip_address",
+            # location (OEP-0030)
             "location", "address", "mailing_address",
-            "gender", "sex",
-            "bio", "biography",
-            "profile_image", "image", "video",
-            "title", "job_title",
-            "social", "website",
+            # gender (OEP-0030) -- bare 'sex' excluded (substring false positives)
+            "gender",
+            # image (OEP-0030) -- generic 'image' excluded; profile_image only
+            "profile_image",
+            # job_title (OEP-0030) -- generic 'title' excluded
+            "job_title",
+            # external_service (OEP-0030) -- bare 'social' and 'website' excluded
+            "social_link",
         ])
         self._pii_terms_cache = [t.strip().lower() for t in raw_terms if t.strip()]
 
@@ -211,16 +208,10 @@ class PiiConfigMixin:
     # ------------------------------------------------------------------
 
     def _contains_pii(self, node):
-        """Recursively inspect *node* for likely PII.
+        """Recursively inspect *node* for likely PII; return the first matching term or None.
 
-        Returns the first matching PII term string, or ``None``.
-
-        NOTE: String literals (Const nodes) are intentionally NOT checked.
-        A log message like ``log.info("user email: unknown")`` contains the
-        word "email" in the message text, but no actual PII value is leaking.
-        Only variable names (Name) and attribute accesses (Attribute) carry
-        real user data and are checked.  Matching Const nodes caused false
-        positives on every log message that described a PII field.
+        Checks Name, Attribute, f-strings, binary ops, dicts, and nested calls.
+        String literals, repr() output, and runtime-constructed strings are NOT checked.
         """
         if node is None:
             return None

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -11,17 +11,13 @@ import re
 from astroid import nodes as astroid_nodes
 
 
-# ---------------------------------------------------------------------------
 # Logging method names that are treated as output sinks.
-# ---------------------------------------------------------------------------
 _LOG_METHODS = frozenset({
     "debug", "info", "warning", "warn", "error",
     "critical", "exception", "log",
 })
 
-# ---------------------------------------------------------------------------
 # Regex patterns used to detect ``.. no_pii:`` in docstrings / comments.
-# ---------------------------------------------------------------------------
 _NO_PII_DOCSTRING_RE = re.compile(r"\.\.\s*no_pii", re.IGNORECASE)
 _NO_PII_COMMENT_RE = re.compile(r"[\s]*#[\s]*\.\.\s*no_pii", re.IGNORECASE)
 
@@ -33,22 +29,11 @@ _DEFAULT_SQUELCH_FLAG = "SQUELCH_PII_IN_LOGS"
 
 
 class PiiConfigMixin:
-    """Mixin that provides cached access to PII-related pylint config options.
-
-    Both :class:`~edx_lint.pylint.pii_squelch_check.PiiMissingSquelchChecker`
-    and :class:`~edx_lint.pylint.pii_annotation_check.PiiAnnotationChecker`
-    inherit from this mixin.
-
-    All options (``pii-terms``, ``pii-safe-functions``, etc.) are defined
-    on ``PiiMissingSquelchChecker``.  The annotation checker reads those
-    values from ``self.linter.config`` via ``getattr`` with safe defaults, so
-    it works correctly whether or not the squelch checker is also loaded.
+    """
+    Mixin that provides cached access to PII-related pylint config options.
     """
 
-    # ------------------------------------------------------------------
     # Initialisation helpers (call from __init__ of each concrete checker)
-    # ------------------------------------------------------------------
-
     def _init_pii_caches(self):
         """Initialise the per-module config cache slots to ``None``."""
         self._pii_terms_cache = None
@@ -56,16 +41,10 @@ class PiiConfigMixin:
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
 
-    # ------------------------------------------------------------------
     # Cached config helpers
-    # ------------------------------------------------------------------
-
     def _ensure_config_cached(self):
-        """Populate the config caches on the first call within a module.
-
-        Reads option values from ``self.linter.config`` using ``getattr``
-        with sensible defaults so that each checker is independently usable
-        even if the other checker (and its options) is not loaded.
+        """
+        Populate the config caches on the first call within a module.
         """
         if self._pii_terms_cache is not None:
             return
@@ -73,29 +52,17 @@ class PiiConfigMixin:
         cfg = self.linter.config
 
         raw_terms = getattr(cfg, "pii_terms", [
-            # email_address (OEP-0030)
             "email", "secondary_email",
-            # username (OEP-0030)
             "username", "retired_username",
-            # password (OEP-0030)
             "password",
-            # name (OEP-0030) -- explicit compound forms only; bare 'name' excluded
             "full_name", "first_name", "last_name",
-            # phone_number (OEP-0030)
             "phone", "phone_number",
-            # birth_date (OEP-0030)
             "birth_date",
-            # ip (OEP-0030) -- bare 'ip' excluded (too short); ip_address only
             "ip_address",
-            # location (OEP-0030)
             "location", "address", "mailing_address",
-            # gender (OEP-0030) -- bare 'sex' excluded (substring false positives)
             "gender",
-            # image (OEP-0030) -- generic 'image' excluded; profile_image only
             "profile_image",
-            # job_title (OEP-0030) -- generic 'title' excluded
             "job_title",
-            # external_service (OEP-0030) -- bare 'social' and 'website' excluded
             "social_link",
         ])
         self._pii_terms_cache = [t.strip().lower() for t in raw_terms if t.strip()]
@@ -139,12 +106,10 @@ class PiiConfigMixin:
     def _squelch_flag(self):
         return getattr(self.linter.config, "pii_squelch_flag", _DEFAULT_SQUELCH_FLAG)
 
-    # ------------------------------------------------------------------
     # SQUELCH_PII_IN_LOGS guard detection
-    # ------------------------------------------------------------------
-
     def _is_inside_squelch_guard(self, node):
-        """Walk up the AST parent chain and return True if *node* is nested
+        """
+        Walk up the AST parent chain and return True if *node* is nested
         inside an ``if`` block that tests the configured squelch flag.
 
         Recognised patterns (flag name is configurable via pii-squelch-flag):
@@ -156,6 +121,7 @@ class PiiConfigMixin:
         5. ``if settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):``
         6. ``if SQUELCH_PII_IN_LOGS.is_enabled():``
         7. ``if not SQUELCH_PII_IN_LOGS.is_active():``
+        8. ``if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):``
         """
         flag = self._squelch_flag()
         current = node.parent
@@ -169,7 +135,9 @@ class PiiConfigMixin:
         return False
 
     def _test_references_flag(self, test, flag):
-        """Return True if AST node *test* references the squelch *flag*."""
+        """
+        Return True if AST node *test* references the squelch *flag*.
+        """
         # Pattern 1: if SQUELCH_PII_IN_LOGS:
         if isinstance(test, astroid_nodes.Name):
             return test.name == flag
@@ -186,9 +154,6 @@ class PiiConfigMixin:
         # Pattern 4: if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
         if isinstance(test, astroid_nodes.Subscript):
             slc = test.slice
-            # astroid < 2.x wrapped subscript slices in an Index node; later
-            # versions removed it.  Use getattr so pylint's static analysis
-            # (no-member / E1101) does not flag the reference on newer astroid.
             _IndexNode = getattr(astroid_nodes, "Index", None)
             if _IndexNode is not None and isinstance(slc, _IndexNode):  # pylint: disable=isinstance-second-argument-not-valid-type
                 slc = slc.value
@@ -210,14 +175,22 @@ class PiiConfigMixin:
                     if self._test_references_flag(func.expr, flag):
                         return True
 
+            # Pattern 8: getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+            if (
+                isinstance(func, astroid_nodes.Name)
+                and func.name == "getattr"
+                and len(test.args) >= 2
+            ):
+                second_arg = test.args[1]
+                if isinstance(second_arg, astroid_nodes.Const) and second_arg.value == flag:
+                        return True
+
         return False
 
-    # ------------------------------------------------------------------
     # Recursive PII detection inside AST subtrees
-    # ------------------------------------------------------------------
-
     def _contains_pii(self, node):
-        """Recursively inspect *node* for likely PII; return the first matching term or None.
+        """
+        Recursively inspect *node* for likely PII; return the first matching term or None.
 
         Checks Name, Attribute, f-strings, binary ops, dicts, and nested calls.
         String literals, repr() output, and runtime-constructed strings are NOT checked.
@@ -277,12 +250,10 @@ class PiiConfigMixin:
 
         return None
 
-    # ------------------------------------------------------------------
     # PII name matching
-    # ------------------------------------------------------------------
-
     def _is_pii_name(self, name):
-        """Return True if *name* is a likely PII identifier.
+        """
+        Return True if *name* is a likely PII identifier.
 
         Rules:
 
@@ -299,30 +270,19 @@ class PiiConfigMixin:
 
     @staticmethod
     def _call_func_name(node):
-        """Return the simple function name for a Call node, or ``None``."""
+        """
+        Return the simple function name for a Call node, or ``None``.
+        """
         if isinstance(node.func, astroid_nodes.Name):
             return node.func.name
         if isinstance(node.func, astroid_nodes.Attribute):
             return node.func.attrname
         return None
 
-    # ------------------------------------------------------------------
     # Django model eligibility detection
-    # ------------------------------------------------------------------
-
     def _is_annotation_eligible_django_model(self, node):
-        """Return True if *node* is an annotation-eligible Django model.
-
-        Replicates the exact predicate used by
-        ``code_annotations.find_django.DjangoSearch.requires_annotations()``:
-
-        1. The class must be a subclass of ``django.db.models.Model`` (detected
-           via astroid's ancestor walking when Django is importable, or via a
-           raw AST base-name BFS over the module's class definitions otherwise).
-        2. The class must **not** be abstract: its inner ``Meta`` class must not
-           contain ``abstract = True``.
-        3. The class must **not** be a proxy model: its inner ``Meta`` class must
-           not contain ``proxy = True``.
+        """
+        Return True if *node* is an annotation-eligible Django model.
         """
         self._ensure_config_cached()
         model_bases = self._django_model_bases_cache
@@ -338,10 +298,8 @@ class PiiConfigMixin:
         except Exception:  # pylint: disable=broad-except
             pass
 
-        # 1b. Fallback: walk raw AST base names.  Handles standalone pylint
-        #     runs where Django is not importable and astroid cannot resolve
-        #     the MRO.  We do a BFS over module-level class definitions
-        #     collected in ``self._module_classdefs``.
+        # 1b. Fallback: walk raw AST base names.Handles standalone pylint
+        #     runs where Django is not importable.
         if not is_model_subclass:
             is_model_subclass = self._raw_ast_is_model_subclass(node)
 
@@ -357,12 +315,8 @@ class PiiConfigMixin:
         return True
 
     def _raw_ast_is_model_subclass(self, node):
-        """Return True if *node* inherits from a known model base via raw AST names.
-
-        BFS over the module-level class definitions.  At each step checks
-        whether any direct base name matches a configured
-        ``pii-django-model-bases`` name, or a class in the same module that
-        is itself a model subclass.
+        """
+        Return True if *node* inherits from a known model base via raw AST names.
         """
         model_bases = self._django_model_bases_cache
         visited = set()
@@ -381,12 +335,8 @@ class PiiConfigMixin:
 
     @staticmethod
     def _direct_base_names(classdef_node):
-        """Yield the simple names of each direct base in *classdef_node*.
-
-        Handles two common forms:
-
-        - ``class Foo(Model):``        → ``Name(name='Model')``
-        - ``class Foo(models.Model):`` → ``Attribute(attrname='Model')``
+        """
+        Yield the simple names of each direct base in *classdef_node*.
         """
         for base in classdef_node.bases:
             if isinstance(base, astroid_nodes.Name):
@@ -396,12 +346,9 @@ class PiiConfigMixin:
 
     @staticmethod
     def _meta_has_true_flag(classdef_node, flag_name):
-        """Return True if the inner ``Meta`` class of *classdef_node* sets
+        """
+        Return True if the inner ``Meta`` class of *classdef_node* sets
         *flag_name* to ``True``.
-
-        Looks for an assignment of the form ``<flag_name> = True`` inside a
-        nested class named ``Meta``.  This is the AST-level equivalent of
-        checking ``model._meta.abstract`` or ``model._meta.proxy`` at runtime.
         """
         for child in classdef_node.body:
             if not (
@@ -422,18 +369,10 @@ class PiiConfigMixin:
                         return True
         return False
 
-    # ------------------------------------------------------------------
     # Class annotation detection (.. no_pii:)
-    # ------------------------------------------------------------------
-
     def _class_has_no_pii_annotation(self, node):
-        """Return True if *node* carries a ``.. no_pii:`` annotation.
-
-        Checks two locations:
-
-        A. The class docstring (primary — edx-platform model convention).
-        B. Comment lines up to ``_ANNOTATION_LOOKAHEAD`` lines above the class
-           keyword (fallback — used in some repos).
+        """
+        Return True if *node* carries a ``.. no_pii:`` annotation.
         """
         return self._docstring_has_no_pii(node) or self._comment_has_no_pii(node)
 
@@ -454,18 +393,10 @@ class PiiConfigMixin:
                 return True
         return False
 
-    # ------------------------------------------------------------------
     # Field scanning inside a class body
-    # ------------------------------------------------------------------
-
     def _collect_pii_fields(self, node):
-        """Return a list of PII-like field names found in the class body.
-
-        Scans three locations:
-
-        1. Class-level ``Assign`` (Django model fields, class variables).
-        2. Class-level ``AnnAssign`` (PEP 526 annotated attributes).
-        3. ``self.attr =`` assignments inside method bodies.
+        """
+        Return a list of PII-like field names found in the class body.
         """
         found = []
         for child in node.body:

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -180,9 +180,12 @@ class PiiConfigMixin:
         # Pattern 4: if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
         if isinstance(test, astroid_nodes.Subscript):
             slc = test.slice
-            # astroid wraps index in an Index node in older versions
-            if hasattr(astroid_nodes, "Index") and isinstance(slc, astroid_nodes.Index):
-                slc = slc.value  # type: ignore[attr-defined]
+            # astroid < 2.x wrapped subscript slices in an Index node; later
+            # versions removed it.  Use getattr so pylint's static analysis
+            # (no-member / E1101) does not flag the reference on newer astroid.
+            _IndexNode = getattr(astroid_nodes, "Index", None)
+            if _IndexNode is not None and isinstance(slc, _IndexNode):  # pylint: disable=isinstance-second-argument-not-valid-type
+                slc = slc.value
             if isinstance(slc, astroid_nodes.Const) and slc.value == flag:
                 return True
 

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -1,88 +1,180 @@
 """
-Shared constants and helpers for the PII pylint checkers.
+Shared PII checker infrastructure: constants, option defaults, and helpers.
 
-Imported by pii_squelch_check and pii_annotation_check; not a checker itself.
-Contains PiiConfigMixin, which provides cached config access and all shared
-PII-detection helpers used by both checkers.
+- ``PiiOptionsChecker``: registers all [PII] pylint options once so both
+  checkers can read them from ``linter.config`` without ordering constraints.
+- ``PiiConfigMixin``: mixin with cached config access and all PII-detection
+  helpers shared by ``PiiMissingSquelchChecker`` and ``PiiAnnotationChecker``.
 """
 
 import re
 
 from astroid import nodes as astroid_nodes
+from pylint.checkers import BaseChecker
+
+from .common import check_visitors
 
 
-# Logging method names that are treated as output sinks.
+# Logging method names treated as output sinks.
 _LOG_METHODS = frozenset({
     "debug", "info", "warning", "warn", "error",
     "critical", "exception", "log",
 })
 
-# Regex patterns used to detect ``.. no_pii:`` in docstrings / comments.
+# Regexes for ``.. no_pii:`` in docstrings and inline comments.
 _NO_PII_DOCSTRING_RE = re.compile(r"\.\.\s*no_pii", re.IGNORECASE)
 _NO_PII_COMMENT_RE = re.compile(r"[\s]*#[\s]*\.\.\s*no_pii", re.IGNORECASE)
 
-# How many lines *above* the ``class`` keyword to search for a comment annotation.
+# Lines above ``class`` to scan for a comment-style annotation.
 _ANNOTATION_LOOKAHEAD = 5
 
-# Default name of the squelch feature flag.
+# Default squelch feature-flag name.
 _DEFAULT_SQUELCH_FLAG = "SQUELCH_PII_IN_LOGS"
 
+# OEP-0030 PII identifier substrings — substring-matched against variable names.
+_DEFAULT_PII_TERMS = [
+    "email", "secondary_email",
+    "username", "retired_username",
+    "password",
+    "full_name", "first_name", "last_name",
+    "phone", "phone_number",
+    "birth_date",
+    "ip_address",
+    "address", "mailing_address",
+    "gender",
+    "profile_image",
+    "job_title",
+    "social_link",
+]
 
+# Exact-match safe keys: identifiers that look like PII but are not sensitive.
+_DEFAULT_SAFE_KEYS = [
+    "user_id", "course_id", "thread_id", "comment_id",
+    "block_id", "usage_id", "usage_key", "anonymous_user_id",
+    "service_username",
+    "email_enabled", "email_sent_on", "email_scheduled",
+    "require_course_email_auth", "reported_content_email_notifications",
+    "email_reminder_sent", "eligibility_email_message", "receipt_email_message",
+    "proctoring_escalation_email", "email_cadence",
+    "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
+    "attr_last_name", "default_last_name", "attr_username", "default_username",
+    "attr_email", "default_email", "skip_email_verification",
+    "location", "_location",
+    "example_full_name",
+]
+
+
+# PiiOptionsChecker — owns all [PII] option declarations.
+@check_visitors
+class PiiOptionsChecker(BaseChecker):
+    """
+    Registers the shared [PII] pylint options (pii-terms, pii-safe-key-patterns,
+    pii-squelch-flag, pii-django-model-bases) so they appear in ``linter.config``
+    before any checker reads them.  No messages or visitors — options only.
+    """
+
+    name = "pii-options"
+
+    options = (
+        (
+            "pii-terms",
+            {
+                "default": ", ".join(_DEFAULT_PII_TERMS),
+                "type": "csv",
+                "metavar": "<comma-separated PII terms>",
+                "help": (
+                    "Comma-separated OEP-0030 PII identifier substrings matched against "
+                    "variable names and attribute accesses passed to log/print/exception "
+                    "sinks.  String literals are NOT matched."
+                ),
+            },
+        ),
+        (
+            "pii-safe-key-patterns",
+            {
+                "default": ", ".join(_DEFAULT_SAFE_KEYS),
+                "type": "csv",
+                "metavar": "<comma-separated safe key patterns>",
+                "help": (
+                    "Exact identifiers that look like PII terms but are approved as "
+                    "non-sensitive (e.g. surrogate keys, flag fields). Exact match only."
+                ),
+            },
+        ),
+        (
+            "pii-squelch-flag",
+            {
+                "default": _DEFAULT_SQUELCH_FLAG,
+                "type": "string",
+                "metavar": "<flag name>",
+                "help": (
+                    "Name of the feature toggle that gates PII-inclusive output. "
+                    "PII sinks must be inside an if-block testing this flag. "
+                    "Default: SQUELCH_PII_IN_LOGS."
+                ),
+            },
+        ),
+        (
+            "pii-django-model-bases",
+            {
+                "default": "Model",
+                "type": "csv",
+                "metavar": "<comma-separated base class names>",
+                "help": (
+                    "Base class names that identify a Django model. "
+                    "Both PII checkers only fire inside non-abstract, non-proxy "
+                    "subclasses of these bases. Default: Model."
+                ),
+            },
+        ),
+    )
+
+
+def register_checkers(linter):
+    """
+    Register the PII options provider.
+    """
+    linter.register_checker(PiiOptionsChecker(linter))
+
+
+# PiiConfigMixin — shared config access and PII-detection helpers.
 class PiiConfigMixin:
     """
-    Mixin that provides cached access to PII-related pylint config options.
+    Mixin providing cached config reads and all PII-detection helpers.
     """
 
-    # Initialisation helpers (call from __init__ of each concrete checker)
     def _init_pii_caches(self):
-        """Initialise the per-module config cache slots to ``None``."""
+        """
+        Reset per-module config cache slots to ``None`` (call from visit_module).
+        """
         self._pii_terms_cache = None
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
 
-    # Cached config helpers
     def _ensure_config_cached(self):
         """
-        Populate the config caches on the first call within a module.
+        Populate config caches from linter.config on the first call per module.
         """
         if self._pii_terms_cache is not None:
             return
 
         cfg = self.linter.config
 
-        raw_terms = getattr(cfg, "pii_terms", [
-            "email", "secondary_email",
-            "username", "retired_username",
-            "password",
-            "full_name", "first_name", "last_name",
-            "phone", "phone_number",
-            "birth_date",
-            "ip_address",
-            "location", "address", "mailing_address",
-            "gender",
-            "profile_image",
-            "job_title",
-            "social_link",
-        ])
-        self._pii_terms_cache = [term.strip().lower() for term in raw_terms if term.strip()]
-
-        raw_keys = getattr(cfg, "pii_safe_key_patterns", [
-            "user_id", "course_id", "thread_id", "comment_id",
-            "block_id", "usage_id", "usage_key", "anonymous_user_id",
-            "service_username",
-            "email_enabled", "email_sent_on", "email_scheduled",
-            "require_course_email_auth", "reported_content_email_notifications",
-            "email_reminder_sent", "eligibility_email_message", "receipt_email_message",
-            "proctoring_escalation_email", "email_cadence",
-            "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
-            "attr_last_name", "default_last_name", "attr_username", "default_username",
-            "attr_email", "default_email", "skip_email_verification",
-            "location", "_location", "example_full_name"
-        ])
-        self._safe_keys_cache = {key.strip().lower() for key in raw_keys if key.strip()}
-
-        raw_bases = getattr(cfg, "pii_django_model_bases", ["Model"])
-        self._django_model_bases_cache = {base.strip() for base in raw_bases if base.strip()}
+        self._pii_terms_cache = [
+            term.strip().lower()
+            for term in getattr(cfg, "pii_terms", _DEFAULT_PII_TERMS)
+            if term.strip()
+        ]
+        self._safe_keys_cache = {
+            key.strip().lower()
+            for key in getattr(cfg, "pii_safe_key_patterns", _DEFAULT_SAFE_KEYS)
+            if key.strip()
+        }
+        self._django_model_bases_cache = {
+            base.strip()
+            for base in getattr(cfg, "pii_django_model_bases", ["Model"])
+            if base.strip()
+        }
 
     def _pii_terms(self):
         self._ensure_config_cached()
@@ -95,13 +187,10 @@ class PiiConfigMixin:
     def _squelch_flag(self):
         return getattr(self.linter.config, "pii_squelch_flag", _DEFAULT_SQUELCH_FLAG)
 
-    # SQUELCH_PII_IN_LOGS guard detection
     def _is_inside_squelch_guard(self, node):
         """
-        Walk up the AST parent chain and return True if *node* is nested
-        inside an ``if`` block that tests the configured squelch flag.
-
-        Recognised patterns (flag name is configurable via pii-squelch-flag):
+        Return True if *node* is nested inside an ``if`` block that tests the
+        configured squelch flag.  Recognised patterns:
 
         1. ``if SQUELCH_PII_IN_LOGS:``
         2. ``if not SQUELCH_PII_IN_LOGS:``
@@ -172,17 +261,15 @@ class PiiConfigMixin:
             ):
                 second_arg = test.args[1]
                 if isinstance(second_arg, astroid_nodes.Const) and second_arg.value == flag:
-                        return True
+                    return True
 
         return False
 
-    # Recursive PII detection inside AST subtrees
     def _contains_pii(self, node):
         """
-        Recursively inspect *node* for likely PII; return the first matching term or None.
-
+        Recursively inspect *node*; return the first PII term found, or None.
         Checks Name, Attribute, f-strings, binary ops, dicts, and nested calls.
-        String literals, repr() output, and runtime-constructed strings are NOT checked.
+        String literals are NOT checked.
         """
         if node is None:
             return None
@@ -236,15 +323,11 @@ class PiiConfigMixin:
 
         return None
 
-    # PII name matching
     def _is_pii_name(self, name):
         """
         Return True if *name* is a likely PII identifier.
 
-        Rules:
-
-        - Exact match against pii-safe-key-patterns → **not** PII.
-        - Substring match of any pii-term inside *name* → PII.
+        Safe-key exact match takes priority; then substring match against pii-terms.
         """
         lower = name.lower()
         if lower in self._safe_keys():
@@ -254,16 +337,14 @@ class PiiConfigMixin:
                 return True
         return False
 
-    # Django model eligibility detection
     def _is_annotation_eligible_django_model(self, node):
         """
-        Return True if *node* is an annotation-eligible Django model.
+        Return True if *node* is a concrete (non-abstract, non-proxy) Django model.
         """
         self._ensure_config_cached()
         model_bases = self._django_model_bases_cache
 
-        # 1a. Try astroid's resolved ancestor walk (works when Django is on
-        #     the import path — i.e. in a real Django project lint run).
+        # Try astroid's resolved ancestor walk first (works when Django is importable).
         is_model_subclass = False
         try:
             for ancestor in node.ancestors():
@@ -273,25 +354,22 @@ class PiiConfigMixin:
         except Exception:  # pylint: disable=broad-except
             pass
 
-        # 1b. Fallback: walk raw AST base names.Handles standalone pylint
-        #     runs where Django is not importable.
+        # Fallback: walk raw AST base names for standalone pylint runs.
         if not is_model_subclass:
             is_model_subclass = self._raw_ast_is_model_subclass(node)
 
         if not is_model_subclass:
             return False
 
-        # 2 & 3. Must not be abstract or proxy (checked via inner Meta class).
-        if self._meta_has_true_flag(node, "abstract"):
-            return False
-        if self._meta_has_true_flag(node, "proxy"):
+        # Skip abstract and proxy models (checked via inner Meta class).
+        if any(self._meta_has_true_flag(node, flag) for flag in ("abstract", "proxy")):
             return False
 
         return True
 
     def _raw_ast_is_model_subclass(self, node):
         """
-        Return True if *node* inherits from a known model base via raw AST names.
+        Return True if *node* inherits from a model base using raw AST names (BFS).
         """
         model_bases = self._django_model_bases_cache
         visited = set()
@@ -311,7 +389,7 @@ class PiiConfigMixin:
     @staticmethod
     def _direct_base_names(classdef_node):
         """
-        Yield the simple names of each direct base in *classdef_node*.
+        Yield the simple name of each direct base class in *classdef_node*.
         """
         for base in classdef_node.bases:
             if isinstance(base, astroid_nodes.Name):
@@ -322,8 +400,7 @@ class PiiConfigMixin:
     @staticmethod
     def _meta_has_true_flag(classdef_node, flag_name):
         """
-        Return True if the inner ``Meta`` class of *classdef_node* sets
-        *flag_name* to ``True``.
+        Return True if the inner ``Meta`` class sets *flag_name* = True.
         """
         for child in classdef_node.body:
             if not (
@@ -344,20 +421,23 @@ class PiiConfigMixin:
                         return True
         return False
 
-    # Class annotation detection (.. no_pii:)
     def _class_has_no_pii_annotation(self, node):
         """
-        Return True if *node* carries a ``.. no_pii:`` annotation.
+        Return True if *node* has a ``.. no_pii:`` annotation (docstring or comment).
         """
         return self._docstring_has_no_pii(node) or self._comment_has_no_pii(node)
 
     def _docstring_has_no_pii(self, node):
-        """Return True if the class docstring contains ``.. no_pii:``."""
+        """
+        Return True if the class docstring contains ``.. no_pii:``.
+        """
         docstring = node.doc_node.value if node.doc_node else ""
         return bool(_NO_PII_DOCSTRING_RE.search(docstring))
 
     def _comment_has_no_pii(self, node):
-        """Return True if a comment annotation appears above the class."""
+        """
+        Return True if a comment annotation appears above the class.
+        """
         if not self._source_lines:
             return False
         # node.lineno is 1-indexed; convert to 0-indexed for list access.
@@ -368,27 +448,26 @@ class PiiConfigMixin:
                 return True
         return False
 
-    # Field scanning inside a class body
     def _collect_pii_fields(self, node):
         """
-        Return a list of PII-like field names found in the class body.
+        Return all PII-like field names found in the class body.
         """
         found = []
         for child in node.body:
-            # Location 1: simple assignment  (email = models.EmailField())
+            # simple assignment: email = models.EmailField()
             if isinstance(child, astroid_nodes.Assign):
                 for target in child.targets:
                     if isinstance(target, astroid_nodes.AssignName):
                         if self._is_pii_name(target.name):
                             found.append(target.name)
 
-            # Location 2: annotated assignment  (email: str = "")
+            # annotated assignment: email: str = ""
             elif isinstance(child, astroid_nodes.AnnAssign):
                 if isinstance(child.target, astroid_nodes.AssignName):
                     if self._is_pii_name(child.target.name):
                         found.append(child.target.name)
 
-            # Location 3: instance attributes inside methods
+            # instance attributes set inside methods: self.email = ...
             elif isinstance(child, astroid_nodes.FunctionDef):
                 for stmt in child.nodes_of_class(astroid_nodes.Assign):
                     for target in stmt.targets:

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -113,10 +113,11 @@ class PiiConfigMixin:
             "email_enabled", "email_sent_on", "email_scheduled",
             "require_course_email_auth", "reported_content_email_notifications",
             "email_reminder_sent", "eligibility_email_message", "receipt_email_message",
+            "proctoring_escalation_email", "email_cadence",
             "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
             "attr_last_name", "default_last_name", "attr_username", "default_username",
             "attr_email", "default_email", "skip_email_verification",
-            "location", "example_full_name"
+            "location", "_location", "example_full_name"
         ])
         self._safe_keys_cache = {k.strip().lower() for k in raw_keys if k.strip()}
 

--- a/edx_lint/pylint/_pii_common.py
+++ b/edx_lint/pylint/_pii_common.py
@@ -9,6 +9,7 @@ Shared PII checker infrastructure: constants, option defaults, and helpers.
 
 import re
 
+from astroid import exceptions as astroid_exceptions
 from astroid import nodes as astroid_nodes
 from pylint.checkers import BaseChecker
 
@@ -26,21 +27,22 @@ _NO_PII_DOCSTRING_RE = re.compile(r"\.\.\s*no_pii", re.IGNORECASE)
 _NO_PII_COMMENT_RE = re.compile(r"[\s]*#[\s]*\.\.\s*no_pii", re.IGNORECASE)
 
 # Lines above ``class`` to scan for a comment-style annotation.
-_ANNOTATION_LOOKAHEAD = 5
+_ANNOTATION_LOOKAHEAD = 10
 
 # Default squelch feature-flag name.
 _DEFAULT_SQUELCH_FLAG = "SQUELCH_PII_IN_LOGS"
 
 # OEP-0030 PII identifier substrings — substring-matched against variable names.
 _DEFAULT_PII_TERMS = [
-    "email", "secondary_email",
-    "username", "retired_username",
+    "email",
+    "username",
     "password",
     "full_name", "first_name", "last_name",
-    "phone", "phone_number",
+    "phone",
     "birth_date",
     "ip_address",
-    "address", "mailing_address",
+    "location",
+    "address",
     "gender",
     "profile_image",
     "job_title",
@@ -59,7 +61,6 @@ _DEFAULT_SAFE_KEYS = [
     "attr_full_name", "default_full_name", "attr_first_name", "default_first_name",
     "attr_last_name", "default_last_name", "attr_username", "default_username",
     "attr_email", "default_email", "skip_email_verification",
-    "location", "_location",
     "example_full_name",
 ]
 
@@ -192,14 +193,14 @@ class PiiConfigMixin:
         Return True if *node* is nested inside an ``if`` block that tests the
         configured squelch flag.  Recognised patterns:
 
-        1. ``if SQUELCH_PII_IN_LOGS:``
-        2. ``if not SQUELCH_PII_IN_LOGS:``
-        3. ``if settings.SQUELCH_PII_IN_LOGS:``
+        1. ``if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):``
+        2. ``if settings.SQUELCH_PII_IN_LOGS:``
+        3. ``if settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):``
         4. ``if settings.FEATURES['SQUELCH_PII_IN_LOGS']:``
-        5. ``if settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):``
-        6. ``if SQUELCH_PII_IN_LOGS.is_enabled():``
-        7. ``if not SQUELCH_PII_IN_LOGS.is_active():``
-        8. ``if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):``
+        5. ``if SQUELCH_PII_IN_LOGS.is_enabled():``
+        6. ``if SQUELCH_PII_IN_LOGS:``
+        7. ``if not SQUELCH_PII_IN_LOGS:``
+        8. ``if not SQUELCH_PII_IN_LOGS.is_active():``
         """
         flag = self._squelch_flag()
         current = node.parent
@@ -216,20 +217,30 @@ class PiiConfigMixin:
         """
         Return True if AST node *test* references the squelch *flag*.
         """
-        # Pattern 1: if SQUELCH_PII_IN_LOGS:
-        if isinstance(test, astroid_nodes.Name):
-            return test.name == flag
+        # Pattern 1: if getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
+        if isinstance(test, astroid_nodes.Call):
+            func = test.func
+            if (
+                isinstance(func, astroid_nodes.Name)
+                and func.name == "getattr"
+                and len(test.args) >= 2
+            ):
+                second_arg = test.args[1]
+                if isinstance(second_arg, astroid_nodes.Const) and second_arg.value == flag:
+                    return True
 
-        # Pattern 2: if not <X>:  — recurse into the operand
-        if isinstance(test, astroid_nodes.UnaryOp) and test.op == "not":
-            return self._test_references_flag(test.operand, flag)
+        # Pattern 2: if settings.SQUELCH_PII_IN_LOGS
+        if isinstance(test, astroid_nodes.Attribute) and test.attrname == flag:
+            return True
 
-        # Pattern 3: if settings.SQUELCH_PII_IN_LOGS:
-        if isinstance(test, astroid_nodes.Attribute):
-            if test.attrname == flag:
-                return True
+        # Pattern 3: if settings.FEATURES.get('SQUELCH_PII_IN_LOGS')
+        if isinstance(test, astroid_nodes.Call) and isinstance(test.func, astroid_nodes.Attribute):
+            if test.func.attrname == "get" and test.args:
+                first_arg = test.args[0]
+                if isinstance(first_arg, astroid_nodes.Const) and first_arg.value == flag:
+                    return True
 
-        # Pattern 4: if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+        # Pattern 4: if settings.FEATURES['SQUELCH_PII_IN_LOGS']
         if isinstance(test, astroid_nodes.Subscript):
             slc = test.slice
             _IndexNode = getattr(astroid_nodes, "Index", None)
@@ -238,29 +249,24 @@ class PiiConfigMixin:
             if isinstance(slc, astroid_nodes.Const) and slc.value == flag:
                 return True
 
-        # Pattern 5 & 6: method calls — dict.get(flag) or flag_obj.is_enabled()
-        if isinstance(test, astroid_nodes.Call):
-            func = test.func
-            if isinstance(func, astroid_nodes.Attribute):
-                method = func.attrname
-                if method in ("get", "is_enabled", "is_active", "is_waffle_flag_active"):
-                    # dict.get('SQUELCH_PII_IN_LOGS') — check first arg
-                    if test.args:
-                        first_arg = test.args[0]
-                        if isinstance(first_arg, astroid_nodes.Const) and first_arg.value == flag:
-                            return True
-                    # flag_obj.is_enabled() — check the receiver
-                    if self._test_references_flag(func.expr, flag):
-                        return True
+        # Pattern 5: if SQUELCH_PII_IN_LOGS.is_enabled()
+        if isinstance(test, astroid_nodes.Call) and isinstance(test.func, astroid_nodes.Attribute):
+            if test.func.attrname in ("is_enabled", "is_waffle_flag_active"):
+                if self._test_references_flag(test.func.expr, flag):
+                    return True
 
-            # Pattern 8: getattr(settings, 'SQUELCH_PII_IN_LOGS', False)
-            if (
-                isinstance(func, astroid_nodes.Name)
-                and func.name == "getattr"
-                and len(test.args) >= 2
-            ):
-                second_arg = test.args[1]
-                if isinstance(second_arg, astroid_nodes.Const) and second_arg.value == flag:
+        # Pattern 6: if SQUELCH_PII_IN_LOGS
+        if isinstance(test, astroid_nodes.Name) and test.name == flag:
+            return True
+
+        # Pattern 7 & 8: negated forms
+        if isinstance(test, astroid_nodes.UnaryOp) and test.op == "not":
+            return self._test_references_flag(test.operand, flag)
+
+        # Backward-compatible method-call forms that still reference the flag.
+        if isinstance(test, astroid_nodes.Call) and isinstance(test.func, astroid_nodes.Attribute):
+            if test.func.attrname in ("is_active",):
+                if self._test_references_flag(test.func.expr, flag):
                     return True
 
         return False
@@ -271,55 +277,56 @@ class PiiConfigMixin:
         Checks Name, Attribute, f-strings, binary ops, dicts, and nested calls.
         String literals are NOT checked.
         """
-        if node is None:
-            return None
+        match node:
+            case None:
+                return None
 
-        # A plain name: check it directly.
-        if isinstance(node, astroid_nodes.Name):
-            if self._is_pii_name(node.name):
-                return node.name
+            # A plain name: check it directly.
+            case astroid_nodes.Name():
+                if self._is_pii_name(node.name):
+                    return node.name
 
-        # An attribute access (e.g. user.email, request.user.username).
-        elif isinstance(node, astroid_nodes.Attribute):
-            if self._is_pii_name(node.attrname):
-                return node.attrname
+            # An attribute access (e.g. user.email, request.user.username).
+            case astroid_nodes.Attribute():
+                if self._is_pii_name(node.attrname):
+                    return node.attrname
 
-        # A call: recurse into args and keyword values.
-        elif isinstance(node, astroid_nodes.Call):
-            for arg in node.args:
-                found = self._contains_pii(arg)
-                if found:
-                    return found
-            for kw in node.keywords or []:
-                found = self._contains_pii(kw.value)
-                if found:
-                    return found
-
-        # f-string: recurse into each formatted value.
-        elif isinstance(node, astroid_nodes.JoinedStr):
-            for value in node.values:
-                if isinstance(value, astroid_nodes.FormattedValue):
-                    found = self._contains_pii(value.value)
+            # A call: recurse into args and keyword values.
+            case astroid_nodes.Call():
+                for arg in node.args:
+                    found = self._contains_pii(arg)
+                    if found:
+                        return found
+                for kw in node.keywords or []:
+                    found = self._contains_pii(kw.value)
                     if found:
                         return found
 
-        # Binary operation (e.g. "hello " + username  or  "email: %s" % email).
-        elif isinstance(node, astroid_nodes.BinOp):
-            return self._contains_pii(node.left) or self._contains_pii(node.right)
+            # f-string: recurse into each formatted value.
+            case astroid_nodes.JoinedStr():
+                for value in node.values:
+                    if isinstance(value, astroid_nodes.FormattedValue):
+                        found = self._contains_pii(value.value)
+                        if found:
+                            return found
 
-        # Tuple / List / Set: recurse into each element.
-        elif isinstance(node, (astroid_nodes.Tuple, astroid_nodes.List, astroid_nodes.Set)):
-            for elt in node.elts:
-                found = self._contains_pii(elt)
-                if found:
-                    return found
+            # Binary operation (e.g. "hello " + username  or  "email: %s" % email).
+            case astroid_nodes.BinOp():
+                return self._contains_pii(node.left) or self._contains_pii(node.right)
 
-        # Dict: recurse into values (keys are usually string identifiers).
-        elif isinstance(node, astroid_nodes.Dict):
-            for _key, value in node.items:
-                found = self._contains_pii(value)
-                if found:
-                    return found
+            # Tuple / List / Set: recurse into each element.
+            case astroid_nodes.Tuple() | astroid_nodes.List() | astroid_nodes.Set():
+                for elt in node.elts:
+                    found = self._contains_pii(elt)
+                    if found:
+                        return found
+
+            # Dict: recurse into values (keys are usually string identifiers).
+            case astroid_nodes.Dict():
+                for _key, value in node.items:
+                    found = self._contains_pii(value)
+                    if found:
+                        return found
 
         return None
 
@@ -351,7 +358,8 @@ class PiiConfigMixin:
                 if ancestor.name in model_bases:
                     is_model_subclass = True
                     break
-        except Exception:  # pylint: disable=broad-except
+        except astroid_exceptions.AstroidError:
+            # Ancestor inference failed; fallback to raw AST base-name walk below.
             pass
 
         # Fallback: walk raw AST base names for standalone pylint runs.

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -10,7 +10,9 @@ from ._pii_common import PiiConfigMixin
 
 
 def register_checkers(linter):
-    """Register the PII annotation checker."""
+    """
+    Register the PII annotation checker.
+    """
     linter.register_checker(PiiAnnotationChecker(linter))
 
 
@@ -24,7 +26,6 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
 
     name = "pii-annotation-checker"
 
-    # Message definitions
     msgs = {
         ("W%d33" % BASE_ID): (
             "Django model '%s' is annotated as no_pii but contains likely PII field(s): %s",
@@ -37,25 +38,20 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
         ),
     }
 
-    # Lifecycle
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Cached per-module source lines for comment-style annotation lookup.
-        self._source_lines = []
-        # Config caches — explicitly initialised here so pylint knows they
-        # exist; reset per-module via _init_pii_caches() in visit_module.
+        self._source_lines = []           # source lines for comment-annotation lookup
+        # Config caches — reset each module via _init_pii_caches() in visit_module.
         self._pii_terms_cache = None
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
-        # Per-module mapping of class name → ClassDef node, used by
-        # _raw_ast_is_model_subclass to resolve same-module ancestors.
-        self._module_classdefs = {}
+        self._module_classdefs = {}       # class name → ClassDef for BFS ancestry
 
-    # AST Visitors
     @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
     def visit_module(self, node):
-        """Cache source lines and reset all per-module state."""
-        # Reset config caches so option values are re-read for each module.
+        """
+        Reset all per-module state and cache source lines for annotation lookup.
+        """
         self._init_pii_caches()
         self._module_classdefs = {}
         try:
@@ -68,9 +64,9 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
     @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
     def visit_classdef(self, node):
         """
-        Detect PII fields in Django model classes annotated with ``.. no_pii:``.
+        Flag PII fields in ``.. no_pii:``-annotated Django model classes.
         """
-        # Index every class definition in the module for same-module ancestry BFS.
+        # Index for same-module ancestry BFS.
         self._module_classdefs[node.name] = node
 
         if not self._is_annotation_eligible_django_model(node):

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -1,0 +1,148 @@
+"""
+PII Annotation Checker for edx-lint.
+
+Detects Django model classes annotated with ``.. no_pii:`` (in their docstring
+or in a comment immediately above the class) that still contain likely-PII
+fields or instance attributes.
+
+Message ID: ``pii-invalid-no-pii-annotation`` (W7633)
+Checker name: ``pii-annotation-checker``
+
+Only Django model classes that are annotation-eligible are checked — i.e.
+classes that are a non-abstract, non-proxy subclass of
+``django.db.models.Model``.  This exactly mirrors the set of models
+considered by ``code_annotations django_find_annotations`` (the
+``DjangoSearch.requires_annotations()`` predicate).
+
+Usage
+-----
+Enable or disable on the command line::
+
+    pylint --enable=pii-invalid-no-pii-annotation  src/
+    pylint --disable=pii-annotation-checker        src/   # disables whole checker
+
+Inline suppression::
+
+    class MyModel(Model):  # pylint: disable=pii-invalid-no-pii-annotation
+        '''.. no_pii:'''
+        email = None  # genuinely safe in this context
+
+Reference: OEP-30 — PII Markup and Auditing
+https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0030-bp-personally-identifiable-information.html
+"""
+
+from pylint.checkers import BaseChecker, utils
+
+from .common import BASE_ID, check_visitors
+from ._pii_common import PiiConfigMixin
+
+
+def register_checkers(linter):
+    """Register the PII annotation checker."""
+    linter.register_checker(PiiAnnotationChecker(linter))
+
+
+@check_visitors
+class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
+    """Checks for stale ``.. no_pii:`` annotations on Django model classes.
+
+    Fires ``pii-invalid-no-pii-annotation`` (W7633) when a concrete
+    (non-abstract, non-proxy) Django model class is annotated with
+    ``.. no_pii:`` yet still contains fields or instance attributes whose
+    names match the configured PII terms.
+
+    Annotation forms recognised:
+
+    * Docstring containing ``.. no_pii:`` (primary — edx-platform convention).
+    * Comment ``# .. no_pii:`` appearing within ``_ANNOTATION_LOOKAHEAD`` lines
+      above the ``class`` keyword (fallback).
+
+    This checker does **not** define its own options.  All PII-related options
+    (``pii-terms``, ``pii-safe-key-patterns``, ``pii-django-model-bases``, etc.)
+    are defined by :class:`~edx_lint.pylint.pii_squelch_check.PiiMissingSquelchChecker`
+    and are read from ``linter.config`` via :class:`~._pii_common.PiiConfigMixin`
+    with safe defaults, so this checker is independently usable even if the
+    squelch checker is not loaded.
+    """
+
+    name = "pii-annotation-checker"
+
+    # ------------------------------------------------------------------
+    # Message definitions
+    # ------------------------------------------------------------------
+    msgs = {
+        ("W%d33" % BASE_ID): (
+            "Django model '%s' is annotated as no_pii but contains likely PII field(s): %s",
+            "pii-invalid-no-pii-annotation",
+            "Django model annotated with '.. no_pii:' contains fields that look like PII. "
+            "Replace the annotation with '.. pii:' and the required metadata, or add "
+            "the field name to pii-safe-key-patterns if it is genuinely non-sensitive. "
+            "Only concrete (non-abstract, non-proxy) Django Model subclasses are checked, "
+            "matching the scope of 'code_annotations django_find_annotations'.",
+        ),
+    }
+
+    # No options are defined here — all shared PII options live on
+    # PiiMissingSquelchChecker and are accessed through self.linter.config.
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Cached per-module source lines for comment-style annotation lookup.
+        self._source_lines = []
+        # Config caches — reset per module, populated lazily on first use.
+        self._init_pii_caches()
+        # Per-module mapping of class name → ClassDef node, used by
+        # _raw_ast_is_model_subclass to resolve same-module ancestors.
+        self._module_classdefs = {}
+
+    # ------------------------------------------------------------------
+    # AST Visitors
+    # ------------------------------------------------------------------
+
+    @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
+    def visit_module(self, node):
+        """Cache source lines and reset all per-module state."""
+        # Reset config caches so option values are re-read for each module.
+        self._pii_terms_cache = None
+        self._safe_functions_cache = None
+        self._safe_keys_cache = None
+        self._django_model_bases_cache = None
+        self._module_classdefs = {}
+        try:
+            module_bytes = node.stream().read()
+            encoding = node.file_encoding or "utf-8"
+            self._source_lines = module_bytes.decode(encoding).splitlines()
+        except Exception:  # pylint: disable=broad-except
+            self._source_lines = []
+
+    @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
+    def visit_classdef(self, node):
+        """Detect PII fields in Django model classes annotated with ``.. no_pii:``.
+
+        Only checks classes that are annotation-eligible Django models, mirroring
+        the ``DjangoSearch.requires_annotations()`` predicate used by
+        ``code_annotations django_find_annotations``:
+
+        - Must be a subclass of ``django.db.models.Model`` (or a configured base).
+        - Must **not** be abstract (no ``abstract = True`` in the inner ``Meta``).
+        - Must **not** be a proxy model (no ``proxy = True`` in the inner ``Meta``).
+        """
+        # Index every class definition in the module for same-module ancestry BFS.
+        self._module_classdefs[node.name] = node
+
+        if not self._is_annotation_eligible_django_model(node):
+            return
+        if not self._class_has_no_pii_annotation(node):
+            return
+
+        pii_fields = self._collect_pii_fields(node)
+        if pii_fields:
+            self.add_message(
+                "pii-invalid-no-pii-annotation",
+                node=node,
+                args=(node.name, ", ".join(pii_fields)),
+            )

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -45,7 +45,6 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
         # Config caches — explicitly initialised here so pylint knows they
         # exist; reset per-module via _init_pii_caches() in visit_module.
         self._pii_terms_cache = None
-        self._safe_functions_cache = None
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
         # Per-module mapping of class name → ClassDef node, used by

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -18,16 +18,13 @@ def register_checkers(linter):
 class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
     """
     Fires ``pii-invalid-no-pii-annotation`` (W7633) when a concrete Django model
-
     is annotated ``.. no_pii:`` but still has fields matching the PII terms list.
     Abstract and proxy models are skipped, mirroring django_find_annotations scope.
     """
 
     name = "pii-annotation-checker"
 
-    # ------------------------------------------------------------------
     # Message definitions
-    # ------------------------------------------------------------------
     msgs = {
         ("W%d33" % BASE_ID): (
             "Django model '%s' is annotated as no_pii but contains likely PII field(s): %s",

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -1,34 +1,6 @@
 """
-PII Annotation Checker for edx-lint.
-
-Detects Django model classes annotated with ``.. no_pii:`` (in their docstring
-or in a comment immediately above the class) that still contain likely-PII
-fields or instance attributes.
-
-Message ID: ``pii-invalid-no-pii-annotation`` (W7633)
-Checker name: ``pii-annotation-checker``
-
-Only Django model classes that are annotation-eligible are checked — i.e.
-classes that are a non-abstract, non-proxy subclass of
-``django.db.models.Model``.  This exactly mirrors the set of models
-considered by ``code_annotations django_find_annotations`` (the
-``DjangoSearch.requires_annotations()`` predicate).
-
-Usage
------
-Enable or disable on the command line::
-
-    pylint --enable=pii-invalid-no-pii-annotation  src/
-    pylint --disable=pii-annotation-checker        src/   # disables whole checker
-
-Inline suppression::
-
-    class MyModel(Model):  # pylint: disable=pii-invalid-no-pii-annotation
-        '''.. no_pii:'''
-        email = None  # genuinely safe in this context
-
-Reference: OEP-30 — PII Markup and Auditing
-https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0030-bp-personally-identifiable-information.html
+PII Annotation Checker — flags Django models annotated ``.. no_pii:`` that
+still contain likely-PII fields or instance attributes (W7633).
 """
 
 from pylint.checkers import BaseChecker, utils
@@ -44,25 +16,10 @@ def register_checkers(linter):
 
 @check_visitors
 class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
-    """Checks for stale ``.. no_pii:`` annotations on Django model classes.
+    """Fires ``pii-invalid-no-pii-annotation`` (W7633) when a concrete Django model
 
-    Fires ``pii-invalid-no-pii-annotation`` (W7633) when a concrete
-    (non-abstract, non-proxy) Django model class is annotated with
-    ``.. no_pii:`` yet still contains fields or instance attributes whose
-    names match the configured PII terms.
-
-    Annotation forms recognised:
-
-    * Docstring containing ``.. no_pii:`` (primary — edx-platform convention).
-    * Comment ``# .. no_pii:`` appearing within ``_ANNOTATION_LOOKAHEAD`` lines
-      above the ``class`` keyword (fallback).
-
-    This checker does **not** define its own options.  All PII-related options
-    (``pii-terms``, ``pii-safe-key-patterns``, ``pii-django-model-bases``, etc.)
-    are defined by :class:`~edx_lint.pylint.pii_squelch_check.PiiMissingSquelchChecker`
-    and are read from ``linter.config`` via :class:`~._pii_common.PiiConfigMixin`
-    with safe defaults, so this checker is independently usable even if the
-    squelch checker is not loaded.
+    is annotated ``.. no_pii:`` but still has fields matching the PII terms list.
+    Abstract and proxy models are skipped, mirroring django_find_annotations scope.
     """
 
     name = "pii-annotation-checker"

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -93,8 +93,12 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
         super().__init__(*args, **kwargs)
         # Cached per-module source lines for comment-style annotation lookup.
         self._source_lines = []
-        # Config caches — reset per module, populated lazily on first use.
-        self._init_pii_caches()
+        # Config caches — explicitly initialised here so pylint knows they
+        # exist; reset per-module via _init_pii_caches() in visit_module.
+        self._pii_terms_cache = None
+        self._safe_functions_cache = None
+        self._safe_keys_cache = None
+        self._django_model_bases_cache = None
         # Per-module mapping of class name → ClassDef node, used by
         # _raw_ast_is_model_subclass to resolve same-module ancestors.
         self._module_classdefs = {}
@@ -107,10 +111,7 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
     def visit_module(self, node):
         """Cache source lines and reset all per-module state."""
         # Reset config caches so option values are re-read for each module.
-        self._pii_terms_cache = None
-        self._safe_functions_cache = None
-        self._safe_keys_cache = None
-        self._django_model_bases_cache = None
+        self._init_pii_caches()
         self._module_classdefs = {}
         try:
             module_bytes = node.stream().read()

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -3,16 +3,32 @@ PII Annotation Checker — flags Django models annotated ``.. no_pii:`` that
 still contain likely-PII fields or instance attributes (W7633).
 """
 
+import re
+
+from astroid import exceptions as astroid_exceptions
+from astroid import nodes as astroid_nodes
 from pylint.checkers import BaseChecker, utils
 
 from .common import BASE_ID, check_visitors
 from ._pii_common import PiiConfigMixin
 
 
+# ---------------------------------------------------------------------------
+# Annotation-specific constants
+# ---------------------------------------------------------------------------
+
+# Regexes that detect ``.. no_pii:`` in class docstrings and comment lines.
+_NO_PII_DOCSTRING_RE = re.compile(r"\.\.\s*no_pii", re.IGNORECASE)
+_NO_PII_COMMENT_RE = re.compile(r"[\s]*#[\s]*\.\.\s*no_pii", re.IGNORECASE)
+
+# Number of source lines *above* the ``class`` statement to scan for a
+# comment-style ``# .. no_pii:`` annotation.  10 lines is wide enough to
+# bridge decorators, blank lines, and other separators.
+_ANNOTATION_LOOKAHEAD = 10
+
+
 def register_checkers(linter):
-    """
-    Register the PII annotation checker.
-    """
+    """Register the PII annotation checker."""
     linter.register_checker(PiiAnnotationChecker(linter))
 
 
@@ -26,6 +42,7 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
 
     name = "pii-annotation-checker"
 
+    # Message definitions
     msgs = {
         ("W%d33" % BASE_ID): (
             "Django model '%s' is annotated as no_pii but contains likely PII field(s): %s",
@@ -38,21 +55,27 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
         ),
     }
 
+    # Lifecycle
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._source_lines = []           # source lines for comment-annotation lookup
-        # Config caches — reset each module via _init_pii_caches() in visit_module.
+        # Cached per-module source lines for comment-style annotation lookup.
+        self._source_lines = []
+        # Config caches — explicitly initialised here so pylint knows they
+        # exist; reset per-module via _init_pii_caches() in visit_module.
         self._pii_terms_cache = None
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
-        self._module_classdefs = {}       # class name → ClassDef for BFS ancestry
+        # Per-module mapping of class name → ClassDef node, used by
+        # _raw_ast_is_model_subclass to resolve same-module ancestors.
+        self._module_classdefs = {}
 
+    # AST Visitors
     @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
     def visit_module(self, node):
-        """
-        Reset all per-module state and cache source lines for annotation lookup.
-        """
+        """Cache source lines and reset all per-module state."""
+        # Reset config caches so option values are re-read for each module.
         self._init_pii_caches()
+        self._django_model_bases_cache = None
         self._module_classdefs = {}
         try:
             module_bytes = node.stream().read()
@@ -64,9 +87,9 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
     @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
     def visit_classdef(self, node):
         """
-        Flag PII fields in ``.. no_pii:``-annotated Django model classes.
+        Detect PII fields in Django model classes annotated with ``.. no_pii:``.
         """
-        # Index for same-module ancestry BFS.
+        # Index every class definition in the module for same-module ancestry BFS.
         self._module_classdefs[node.name] = node
 
         if not self._is_annotation_eligible_django_model(node):
@@ -81,3 +104,179 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
                 node=node,
                 args=(node.name, ", ".join(pii_fields)),
             )
+
+    # Django model eligibility helpers
+    def _is_annotation_eligible_django_model(self, node):
+        """
+        Return True if *node* is a concrete (non-abstract, non-proxy) Django model.
+
+        Tries astroid's resolved ancestor walk first (works when Django is importable),
+        then falls back to raw AST base-name BFS for standalone pylint runs.
+        """
+        model_bases = self._django_model_bases()
+
+        # Primary path: astroid type-inference ancestor resolution.
+        is_model_subclass = False
+        try:
+            for ancestor in node.ancestors():
+                if ancestor.name in model_bases:
+                    is_model_subclass = True
+                    break
+        except astroid_exceptions.AstroidError:
+            # Inference failed (e.g. Django not installed) — fall back to raw AST.
+            pass
+
+        # Fallback: walk raw AST base names for standalone/offline runs.
+        if not is_model_subclass:
+            is_model_subclass = self._raw_ast_is_model_subclass(node)
+
+        if not is_model_subclass:
+            return False
+
+        # Skip abstract and proxy models (detected via inner Meta class).
+        if any(self._meta_has_true_flag(node, flag) for flag in ("abstract", "proxy")):
+            return False
+
+        return True
+
+    def _django_model_bases(self):
+        """
+        Return the set of base class names that identify a Django model.
+
+        Lazily initialised from ``pii-django-model-bases`` linter option on
+        first call per module; reset to None by visit_module so options are
+        re-read for each module.
+        """
+        if self._django_model_bases_cache is None:
+            raw = getattr(self.linter.config, "pii_django_model_bases", ["Model"])
+            self._django_model_bases_cache = {b.strip() for b in raw if b.strip()}
+        return self._django_model_bases_cache
+
+    def _raw_ast_is_model_subclass(self, node):
+        """
+        Return True if *node* inherits from a model base by BFS over raw AST names.
+
+        Only classes defined in the same module can be followed transitively.
+        External bases (e.g. ``django.db.models.Model``) are matched by bare
+        name against ``pii-django-model-bases``.
+        """
+        model_bases = self._django_model_bases()
+        visited = set()
+        queue = list(self._direct_base_names(node))
+        while queue:
+            name = queue.pop(0)
+            if name in visited:
+                continue
+            visited.add(name)
+            if name in model_bases:
+                return True
+            # Follow same-module parent if known.
+            parent_node = self._module_classdefs.get(name)
+            if parent_node is not None:
+                queue.extend(self._direct_base_names(parent_node))
+        return False
+
+    @staticmethod
+    def _direct_base_names(classdef_node):
+        """
+        Yield the simple name of each direct base class in *classdef_node*.
+
+        Handles both ``Name`` nodes (``Model``) and ``Attribute`` nodes
+        (``models.Model`` → yields ``"Model"``).
+        """
+        for base in classdef_node.bases:
+            if isinstance(base, astroid_nodes.Name):
+                yield base.name
+            elif isinstance(base, astroid_nodes.Attribute):
+                yield base.attrname
+
+    @staticmethod
+    def _meta_has_true_flag(classdef_node, flag_name):
+        """
+        Return True if the inner ``Meta`` class sets ``flag_name = True``.
+        """
+        for child in classdef_node.body:
+            if not (isinstance(child, astroid_nodes.ClassDef) and child.name == "Meta"):
+                continue
+            for stmt in child.body:
+                if not isinstance(stmt, astroid_nodes.Assign):
+                    continue
+                for target in stmt.targets:
+                    if (isinstance(target, astroid_nodes.AssignName)
+                            and target.name == flag_name
+                            and isinstance(stmt.value, astroid_nodes.Const)
+                            and stmt.value.value is True):
+                        return True
+        return False
+
+    # Annotation detection helpers
+    def _class_has_no_pii_annotation(self, node):
+        """
+        Return True if *node* carries a ``.. no_pii:`` annotation.
+
+        Checks the class docstring first, then comment lines above the class.
+        """
+        return self._docstring_has_no_pii(node) or self._comment_has_no_pii(node)
+
+    def _docstring_has_no_pii(self, node):
+        """
+        Return True if the class docstring contains ``.. no_pii:``.
+        """
+        docstring = node.doc_node.value if node.doc_node else ""
+        return bool(_NO_PII_DOCSTRING_RE.search(docstring))
+
+    def _comment_has_no_pii(self, node):
+        """
+        Return True if a ``# .. no_pii:`` comment appears above the class.
+
+        Scans up to ``_ANNOTATION_LOOKAHEAD`` source lines before the class
+        statement, covering decorators and blank lines between the comment and
+        the class declaration.
+        """
+        if not self._source_lines:
+            return False
+        # node.lineno is 1-indexed; convert to 0-indexed for list access.
+        end = node.lineno - 1       # exclusive (the ``class`` line itself)
+        start = max(0, end - _ANNOTATION_LOOKAHEAD)
+        for line in self._source_lines[start:end]:
+            if _NO_PII_COMMENT_RE.match(line):
+                return True
+        return False
+
+    # Field collection helpers
+    def _collect_pii_fields(self, node):
+        """
+        Return all PII-like field name strings found in the class body.
+
+        Scans:
+        - Class-level ``Assign`` targets:    ``email = models.EmailField()``
+        - Class-level ``AnnAssign`` targets: ``email: str = ""``
+        - ``self.X`` attribute assignments in method bodies, reported as ``"self.X"``.
+        """
+        found = []
+
+        for child in node.body:
+            # Class-level simple assignment: ``email = ...``
+            if isinstance(child, astroid_nodes.Assign):
+                for target in child.targets:
+                    if isinstance(target, astroid_nodes.AssignName):
+                        if self._is_pii_name(target.name):
+                            found.append(target.name)
+
+            # Class-level annotated assignment: ``email: str = ""``
+            elif isinstance(child, astroid_nodes.AnnAssign):
+                if isinstance(child.target, astroid_nodes.AssignName):
+                    if self._is_pii_name(child.target.name):
+                        found.append(child.target.name)
+
+            # Instance attributes set inside methods: ``self.email = ...``
+            elif isinstance(child, astroid_nodes.FunctionDef):
+                for stmt in child.nodes_of_class(astroid_nodes.Assign):
+                    for target in stmt.targets:
+                        if (isinstance(target, astroid_nodes.AssignAttr)
+                                and isinstance(target.expr, astroid_nodes.Name)
+                                and target.expr.name == "self"
+                                and self._is_pii_name(target.attrname)):
+                            found.append(f"self.{target.attrname}")
+
+        return found

--- a/edx_lint/pylint/pii_annotation_check.py
+++ b/edx_lint/pylint/pii_annotation_check.py
@@ -16,7 +16,8 @@ def register_checkers(linter):
 
 @check_visitors
 class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
-    """Fires ``pii-invalid-no-pii-annotation`` (W7633) when a concrete Django model
+    """
+    Fires ``pii-invalid-no-pii-annotation`` (W7633) when a concrete Django model
 
     is annotated ``.. no_pii:`` but still has fields matching the PII terms list.
     Abstract and proxy models are skipped, mirroring django_find_annotations scope.
@@ -39,13 +40,7 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
         ),
     }
 
-    # No options are defined here — all shared PII options live on
-    # PiiMissingSquelchChecker and are accessed through self.linter.config.
-
-    # ------------------------------------------------------------------
     # Lifecycle
-    # ------------------------------------------------------------------
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Cached per-module source lines for comment-style annotation lookup.
@@ -60,10 +55,7 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
         # _raw_ast_is_model_subclass to resolve same-module ancestors.
         self._module_classdefs = {}
 
-    # ------------------------------------------------------------------
     # AST Visitors
-    # ------------------------------------------------------------------
-
     @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
     def visit_module(self, node):
         """Cache source lines and reset all per-module state."""
@@ -79,15 +71,8 @@ class PiiAnnotationChecker(PiiConfigMixin, BaseChecker):
 
     @utils.only_required_for_messages("pii-invalid-no-pii-annotation")
     def visit_classdef(self, node):
-        """Detect PII fields in Django model classes annotated with ``.. no_pii:``.
-
-        Only checks classes that are annotation-eligible Django models, mirroring
-        the ``DjangoSearch.requires_annotations()`` predicate used by
-        ``code_annotations django_find_annotations``:
-
-        - Must be a subclass of ``django.db.models.Model`` (or a configured base).
-        - Must **not** be abstract (no ``abstract = True`` in the inner ``Meta``).
-        - Must **not** be a proxy model (no ``proxy = True`` in the inner ``Meta``).
+        """
+        Detect PII fields in Django model classes annotated with ``.. no_pii:``.
         """
         # Index every class definition in the module for same-module ancestry BFS.
         self._module_classdefs[node.name] = node

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -1,47 +1,6 @@
 """
-PII Missing Squelch Checker for edx-lint.
-
-Detects logging calls, ``print``/stdout/stderr writes, and raised exceptions
-that contain likely-PII variable references but are **not** wrapped by a
-``SQUELCH_PII_IN_LOGS`` guard.
-
-All three message IDs are grouped under the single checker name
-``pii-missing-squelch``.  This means:
-
-* Enabling/disabling the checker on the command line controls all three
-  messages at once::
-
-      pylint --enable=pii-missing-squelch  src/
-      pylint --disable=pii-missing-squelch src/
-
-* Individual messages can still be targeted (or suppressed inline) using
-  their own symbolic IDs::
-
-      # pylint: disable=pii-missing-squelch
-      log.info("email=%s", email)
-
-Message IDs
------------
-
-====================  ======  ================================================================
-Symbol                Code    Description
-====================  ======  ================================================================
-pii-missing-squelch   W7630   Log, print, or exception exposes PII without a SQUELCH guard
-====================  ======  ================================================================
-
-A "guard" is any ``if`` statement (at any ancestor level) whose test
-references the configured squelch flag in one of the recognised patterns::
-
-    settings.FEATURES['SQUELCH_PII_IN_LOGS']
-    settings.FEATURES.get('SQUELCH_PII_IN_LOGS')
-    settings.SQUELCH_PII_IN_LOGS
-    SQUELCH_PII_IN_LOGS                         (bare name)
-    not SQUELCH_PII_IN_LOGS                     (negated)
-    SQUELCH_PII_IN_LOGS.is_enabled()
-    SQUELCH_PII_IN_LOGS.is_active()
-
-Reference: OEP-30 — PII Markup and Auditing
-https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0030-bp-personally-identifiable-information.html
+PII Missing Squelch Checker — flags log/print/exception calls inside Django
+model methods that expose PII without a SQUELCH_PII_IN_LOGS guard (W7630).
 """
 
 from astroid import nodes as astroid_nodes
@@ -58,22 +17,10 @@ def register_checkers(linter):
 
 @check_visitors
 class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
-    """Checks for unsafe PII exposure in logs, print statements, and raised exceptions.
+    """Flags unguarded PII in log/print/exception calls inside Django model methods.
 
-    A single message ``pii-missing-squelch`` is emitted for all three sink
-    types (logging, print/stdout/stderr, raised exception), so viewers see
-    only ``pii-missing-squelch`` in pylint output and never need to know the
-    three underlying patterns — they simply add a ``SQUELCH_PII_IN_LOGS``
-    guard to the flagged line.
-
-    Enable/disable the entire family with one command::
-
-        pylint --enable=pii-missing-squelch  src/
-        pylint --disable=pii-missing-squelch src/
-
-    Squelch checks are **only enforced** inside non-abstract, non-proxy Django
-    model classes that are *not* annotated with ``.. no_pii:``.  Standalone
-    functions and ``.. no_pii:`` models are completely exempt.
+    Fires ``pii-missing-squelch`` (W7630). Skips .. no_pii: models, abstract/proxy
+    models, standalone functions, and any call wrapped in a SQUELCH_PII_IN_LOGS guard.
     """
 
     name = "pii-missing-squelch"

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -99,9 +99,10 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                     "email_enabled,email_sent_on,email_scheduled,"
                     "require_course_email_auth,reported_content_email_notifications,"
                     "email_reminder_sent,eligibility_email_message,receipt_email_message,"
+                    "proctoring_escalation_email,email_cadence,"
                     "attr_full_name,default_full_name,attr_first_name,default_first_name,"
                     "attr_last_name,default_last_name,attr_username,default_username,"
-                    "attr_email,default_email,skip_email_verification,location,"
+                    "attr_email,default_email,skip_email_verification,location,_location,"
                     "example_full_name"
                 ),
                 "type": "csv",

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -95,7 +95,14 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
             {
                 "default": (
                     "user_id,course_id,thread_id,comment_id,block_id,"
-                    "usage_id,usage_key,anonymous_user_id"
+                    "usage_id,usage_key,anonymous_user_id,service_username,"
+                    "email_enabled,email_sent_on,email_scheduled,"
+                    "require_course_email_auth,reported_content_email_notifications,"
+                    "email_reminder_sent,eligibility_email_message,receipt_email_message,"
+                    "attr_full_name,default_full_name,attr_first_name,default_first_name,"
+                    "attr_last_name,default_last_name,attr_username,default_username,"
+                    "attr_email,default_email,skip_email_verification,location,"
+                    "example_full_name"
                 ),
                 "type": "csv",
                 "metavar": "<comma-separated safe key patterns>",

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -194,8 +194,12 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         super().__init__(*args, **kwargs)
         # Cached per-module source lines for comment-style annotation lookup.
         self._source_lines = []
-        # Config caches — reset per module, populated lazily on first use.
-        self._init_pii_caches()
+        # Config caches — explicitly initialised here so pylint knows they
+        # exist; reset per-module via _init_pii_caches() in visit_module.
+        self._pii_terms_cache = None
+        self._safe_functions_cache = None
+        self._safe_keys_cache = None
+        self._django_model_bases_cache = None
         # Per-module mapping of class name → ClassDef node, used by
         # _raw_ast_is_model_subclass to resolve same-module ancestors.
         self._module_classdefs = {}
@@ -210,10 +214,7 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
     def visit_module(self, node):
         """Cache source lines and reset all per-module state."""
         # Reset config caches so options are re-read for each module.
-        self._pii_terms_cache = None
-        self._safe_functions_cache = None
-        self._safe_keys_cache = None
-        self._django_model_bases_cache = None
+        self._init_pii_caches()
         self._module_classdefs = {}
         try:
             module_bytes = node.stream().read()

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -7,11 +7,13 @@ from astroid import nodes as astroid_nodes
 from pylint.checkers import BaseChecker, utils
 
 from .common import BASE_ID, check_visitors
-from ._pii_common import _LOG_METHODS, _DEFAULT_SQUELCH_FLAG, PiiConfigMixin
+from ._pii_common import _LOG_METHODS, PiiConfigMixin
 
 
 def register_checkers(linter):
-    """Register the PII missing-squelch checker."""
+    """
+    Register the PII missing-squelch checker.
+    """
     linter.register_checker(PiiMissingSquelchChecker(linter))
 
 
@@ -23,7 +25,6 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
 
     name = "pii-missing-squelch"
 
-    # Message definitions — one symbol covers log + print + exception
     msgs = {
         ("W%d30" % BASE_ID): (
             "PII term '%s' exposed in %s without a SQUELCH_PII_IN_LOGS guard. "
@@ -31,116 +32,24 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
             "pii-missing-squelch",
             "A log call, print/stdout/stderr write, or raised exception inside a "
             "Django model method exposes likely PII without a SQUELCH_PII_IN_LOGS "
-            "guard.  Wrap the offending line with: if not SQUELCH_PII_IN_LOGS: ...",
+            "guard. Wrap the offending line with: if not SQUELCH_PII_IN_LOGS: ...",
         ),
     }
 
-    # Configurable options
-    # NOTE: All shared PII options are defined here.  PiiAnnotationChecker
-    #       reads them from linter.config via getattr() with safe defaults.
-    options = (
-        (
-            "pii-terms",
-            {
-                "default": (
-                    # Curated OEP-0030 PII identifiers. Generic terms (name, ip, sex,
-                    # image, video, title, bio, social, website) excluded to avoid false
-                    # positives; add them back via this option in your pylintrc if needed.
-                    "email, secondary_email, "
-                    "username, retired_username, "
-                    "password, "
-                    "full_name, first_name, last_name, "
-                    "phone, phone_number, "
-                    "birth_date, "
-                    "ip_address, "
-                    "location, address, mailing_address, "
-                    "gender, "
-                    "profile_image, "
-                    "job_title, "
-                    "social_link"
-                ),
-                "type": "csv",
-                "metavar": "<comma-separated PII terms>",
-                "help": (
-                    "Comma-separated OEP-0030 PII identifier substrings matched against variable "
-                    "names and attribute accesses passed to log/print/exception sinks. "
-                    "String literals are NOT matched — only actual variable/attribute references."
-                ),
-            },
-        ),
-        (
-            "pii-safe-key-patterns",
-            {
-                "default": (
-                    "user_id, course_id, thread_id, comment_id, block_id, "
-                    "usage_id, usage_key, anonymous_user_id, service_username, "
-                    "email_enabled, email_sent_on, email_scheduled, "
-                    "require_course_email_auth, reported_content_email_notifications, "
-                    "email_reminder_sent, eligibility_email_message, receipt_email_message, "
-                    "proctoring_escalation_email, email_cadence, "
-                    "attr_full_name, default_full_name, attr_first_name, default_first_name, "
-                    "attr_last_name, default_last_name, attr_username, default_username, "
-                    "attr_email, default_email, skip_email_verification, location, _location, "
-                    "example_full_name"
-                ),
-                "type": "csv",
-                "metavar": "<comma-separated safe key patterns>",
-                "help": (
-                    "Exact identifiers that look like PII terms but are approved as "
-                    "non-sensitive (e.g. surrogate keys). Exact match only."
-                ),
-            },
-        ),
-        (
-            "pii-squelch-flag",
-            {
-                "default": _DEFAULT_SQUELCH_FLAG,
-                "type": "string",
-                "metavar": "<flag name>",
-                "help": (
-                    "Name of the feature toggle that gates PII-inclusive log/print/exception "
-                    "output. PII sinks must be inside an if-block that tests this flag. "
-                    "Default: SQUELCH_PII_IN_LOGS."
-                ),
-            },
-        ),
-        (
-            "pii-django-model-bases",
-            {
-                "default": "Model",
-                "type": "csv",
-                "metavar": "<comma-separated base class names>",
-                "help": (
-                    "Comma-separated list of base class *names* that identify a Django model. "
-                    "The squelch checks only fire inside non-abstract, non-proxy subclasses of "
-                    "these bases (mirroring 'code_annotations django_find_annotations'). "
-                    "Default: Model."
-                ),
-            },
-        ),
-    )
-
-    # Lifecycle
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Cached per-module source lines for comment-style annotation lookup.
-        self._source_lines = []
-        # Config caches — explicitly initialised here so pylint knows they
-        # exist; reset per-module via _init_pii_caches() in visit_module.
+        self._source_lines = []           # source lines for comment-annotation lookup
+        # Config caches — reset each module via _init_pii_caches() in visit_module.
         self._pii_terms_cache = None
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
-        # Per-module mapping of class name → ClassDef node, used by
-        # _raw_ast_is_model_subclass to resolve same-module ancestors.
-        self._module_classdefs = {}
+        self._module_classdefs = {}       # class name → ClassDef for BFS ancestry
 
-    # AST Visitors
-    @utils.only_required_for_messages(
-        "pii-missing-squelch"
-    )
+    @utils.only_required_for_messages("pii-missing-squelch")
     def visit_module(self, node):
-        """Cache source lines and reset all per-module state."""
-        # Reset config caches so options are re-read for each module.
+        """
+        Reset all per-module state and cache source lines for annotation lookup.
+        """
         self._init_pii_caches()
         self._module_classdefs = {}
         try:
@@ -153,14 +62,14 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_classdef(self, node):
         """
-        Index every class definition for same-module ancestry resolution.
+        Index class definitions for same-module ancestry resolution.
         """
         self._module_classdefs[node.name] = node
 
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_call(self, node):
         """
-        Check logging and print/stdout/stderr calls for unguarded PII.
+        Check log and print/stdout/stderr calls for unguarded PII.
         """
         if self._is_log_call(node):
             self._check_sink(node, "log call")
@@ -170,14 +79,10 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_raise(self, node):
         """
-        Check raised exceptions for unguarded PII in their messages.
+        Check raised exceptions for unguarded PII.
         """
-        if not self._requires_squelch_check(node):
-            return
-        if node.exc is None:
-            return
         exc = node.exc
-        if not isinstance(exc, astroid_nodes.Call):
+        if not self._requires_squelch_check(node) or exc is None or not isinstance(exc, astroid_nodes.Call):
             return
         all_args = list(exc.args) + [kw.value for kw in (exc.keywords or [])]
         for arg in all_args:
@@ -191,10 +96,9 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                     )
                 return  # at most one message per raise
 
-    # Sink identification helpers
     def _is_log_call(self, node):
         """
-        Return True if *node* is a call to a standard logging method.
+        Return True if *node* is a standard logging method call.
         """
         if not isinstance(node.func, astroid_nodes.Attribute):
             return False
@@ -202,27 +106,29 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
 
     def _is_print_call(self, node):
         """
-        Return True if *node* is a print() or stdout/stderr write() call.
+        Return True if *node* is a print() or sys.stdout/stderr write() call.
         """
         # bare print()
         if isinstance(node.func, astroid_nodes.Name) and node.func.name == "print":
             return True
-        # self.stdout.write(...)  /  sys.stdout.write(...)  /  stderr.write(...)
-        if isinstance(node.func, astroid_nodes.Attribute) and node.func.attrname == "write":
+        # sys.stdout.write(...) / sys.stderr.write(...) / self.stdout.write(...)
+        if (
+            isinstance(node.func, astroid_nodes.Attribute)
+            and node.func.attrname == "write"
+            and isinstance(node.func.expr, astroid_nodes.Attribute)
+            and node.func.expr.attrname in ("stdout", "stderr")
+        ):
             return True
         return False
 
     def _check_sink(self, node, sink_label):
         """
-        Emit ``pii-missing-squelch`` if any argument of *node* contains PII
-        and the call is not inside a SQUELCH_PII_IN_LOGS guard.
+        Emit ``pii-missing-squelch`` if *node* has a PII argument outside a squelch guard.
         """
         if not self._requires_squelch_check(node):
             return
 
-        all_args = list(node.args)
-        for kw in node.keywords or []:
-            all_args.append(kw.value)
+        all_args = list(node.args) + [kw.value for kw in (node.keywords or [])]
         for arg in all_args:
             pii_term = self._contains_pii(arg)
             if pii_term:
@@ -236,14 +142,13 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
 
     def _requires_squelch_check(self, node):
         """
-        Return True if *node* is inside an eligible Django model that is
-        NOT annotated with ``.. no_pii:``.
+        Return True if *node* is inside an eligible Django model without ``.. no_pii:``.
         """
         current = node.parent
         while current is not None:
             if isinstance(current, astroid_nodes.ClassDef):
                 if self._is_annotation_eligible_django_model(current):
-                    # Inside an eligible model — require guard ONLY if not safe.
+                    # Require squelch guard only when the model lacks .. no_pii:.
                     return not self._class_has_no_pii_annotation(current)
                 # Inside a non-model class — keep walking up.
             current = current.parent

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -68,8 +68,6 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                 ),
             },
         ),
-
-
         (
             "pii-safe-functions",
             {

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -1,0 +1,344 @@
+"""
+PII Missing Squelch Checker for edx-lint.
+
+Detects logging calls, ``print``/stdout/stderr writes, and raised exceptions
+that contain likely-PII variable references but are **not** wrapped by a
+``SQUELCH_PII_IN_LOGS`` guard.
+
+All three message IDs are grouped under the single checker name
+``pii-missing-squelch``.  This means:
+
+* Enabling/disabling the checker on the command line controls all three
+  messages at once::
+
+      pylint --enable=pii-missing-squelch  src/
+      pylint --disable=pii-missing-squelch src/
+
+* Individual messages can still be targeted (or suppressed inline) using
+  their own symbolic IDs::
+
+      # pylint: disable=pii-missing-squelch
+      log.info("email=%s", email)
+
+Message IDs
+-----------
+
+====================  ======  ================================================================
+Symbol                Code    Description
+====================  ======  ================================================================
+pii-missing-squelch   W7630   Log, print, or exception exposes PII without a SQUELCH guard
+====================  ======  ================================================================
+
+A "guard" is any ``if`` statement (at any ancestor level) whose test
+references the configured squelch flag in one of the recognised patterns::
+
+    settings.FEATURES['SQUELCH_PII_IN_LOGS']
+    settings.FEATURES.get('SQUELCH_PII_IN_LOGS')
+    settings.SQUELCH_PII_IN_LOGS
+    SQUELCH_PII_IN_LOGS                         (bare name)
+    not SQUELCH_PII_IN_LOGS                     (negated)
+    SQUELCH_PII_IN_LOGS.is_enabled()
+    SQUELCH_PII_IN_LOGS.is_active()
+
+Reference: OEP-30 — PII Markup and Auditing
+https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0030-bp-personally-identifiable-information.html
+"""
+
+from astroid import nodes as astroid_nodes
+from pylint.checkers import BaseChecker, utils
+
+from .common import BASE_ID, check_visitors
+from ._pii_common import _LOG_METHODS, _DEFAULT_SQUELCH_FLAG, PiiConfigMixin
+
+
+def register_checkers(linter):
+    """Register the PII missing-squelch checker."""
+    linter.register_checker(PiiMissingSquelchChecker(linter))
+
+
+@check_visitors
+class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
+    """Checks for unsafe PII exposure in logs, print statements, and raised exceptions.
+
+    A single message ``pii-missing-squelch`` is emitted for all three sink
+    types (logging, print/stdout/stderr, raised exception), so viewers see
+    only ``pii-missing-squelch`` in pylint output and never need to know the
+    three underlying patterns — they simply add a ``SQUELCH_PII_IN_LOGS``
+    guard to the flagged line.
+
+    Enable/disable the entire family with one command::
+
+        pylint --enable=pii-missing-squelch  src/
+        pylint --disable=pii-missing-squelch src/
+
+    Squelch checks are **only enforced** inside non-abstract, non-proxy Django
+    model classes that are *not* annotated with ``.. no_pii:``.  Standalone
+    functions and ``.. no_pii:`` models are completely exempt.
+    """
+
+    name = "pii-missing-squelch"
+
+    # ------------------------------------------------------------------
+    # Message definitions — one symbol covers log + print + exception
+    # ------------------------------------------------------------------
+    msgs = {
+        ("W%d30" % BASE_ID): (
+            "PII term '%s' exposed in %s without a SQUELCH_PII_IN_LOGS guard. "
+            "Wrap with: if not SQUELCH_PII_IN_LOGS: ...",
+            "pii-missing-squelch",
+            "A log call, print/stdout/stderr write, or raised exception inside a "
+            "Django model method exposes likely PII without a SQUELCH_PII_IN_LOGS "
+            "guard.  Wrap the offending line with: if not SQUELCH_PII_IN_LOGS: ...",
+        ),
+    }
+
+    # ------------------------------------------------------------------
+    # Configurable options
+    # NOTE: All shared PII options are defined here.  PiiAnnotationChecker
+    #       reads them from linter.config via getattr() with safe defaults.
+    # ------------------------------------------------------------------
+    options = (
+        (
+            "pii-terms",
+            {
+                "default": (
+                    # OEP-0030 PII fields (https://open-edx-proposals.readthedocs.io/en/latest/
+                    # architectural-decisions/oep-0030-arch-pii-markup-and-auditing.html)
+                    "email,secondary_email,"           # email_address
+                    "username,retired_username,"       # username
+                    "password,"                        # password
+                    "name,full_name,first_name,last_name,"  # name
+                    "phone,phone_number,"              # phone_number
+                    "birth_date,"                      # birth_date
+                    "ip,ip_address,"                   # ip
+                    "location,address,mailing_address,"  # location
+                    "gender,sex,"                      # gender / sex
+                    "bio,biography,"                   # biography
+                    "profile_image,image,video,"       # image / video
+                    "title,job_title,"                 # job title
+                    "social,website"                   # external_service (social media, website)
+                ),
+                "type": "csv",
+                "metavar": "<comma-separated PII terms>",
+                "help": (
+                    "Comma-separated list of identifier substrings treated as PII per OEP-0030. "
+                    "Matches variable names and attribute accesses passed to log/print/exception "
+                    "sinks. String literals in log messages are NOT matched — only actual PII "
+                    "variable and attribute references are flagged."
+                ),
+            },
+        ),
+        (
+            "pii-safe-functions",
+            {
+                "default": (
+                    "redact,redact_pii,mask,mask_pii,hash_pii,obfuscate,obfuscate_pii"
+                ),
+                "type": "csv",
+                "metavar": "<comma-separated safe function names>",
+                "help": (
+                    "Functions that safely transform PII. Calls wrapped in one of these "
+                    "functions will not be flagged."
+                ),
+            },
+        ),
+        (
+            "pii-safe-key-patterns",
+            {
+                "default": (
+                    "user_id,course_id,thread_id,comment_id,block_id,"
+                    "usage_id,usage_key,anonymous_user_id"
+                ),
+                "type": "csv",
+                "metavar": "<comma-separated safe key patterns>",
+                "help": (
+                    "Exact identifiers that look like PII terms but are approved as "
+                    "non-sensitive (e.g. surrogate keys). Exact match only."
+                ),
+            },
+        ),
+        (
+            "pii-squelch-flag",
+            {
+                "default": _DEFAULT_SQUELCH_FLAG,
+                "type": "string",
+                "metavar": "<flag name>",
+                "help": (
+                    "Name of the feature toggle that gates PII-inclusive log/print/exception "
+                    "output. PII sinks must be inside an if-block that tests this flag. "
+                    "Default: SQUELCH_PII_IN_LOGS."
+                ),
+            },
+        ),
+        (
+            "pii-django-model-bases",
+            {
+                "default": "Model",
+                "type": "csv",
+                "metavar": "<comma-separated base class names>",
+                "help": (
+                    "Comma-separated list of base class *names* that identify a Django model. "
+                    "The squelch checks only fire inside non-abstract, non-proxy subclasses of "
+                    "these bases (mirroring 'code_annotations django_find_annotations'). "
+                    "Default: Model."
+                ),
+            },
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Cached per-module source lines for comment-style annotation lookup.
+        self._source_lines = []
+        # Config caches — reset per module, populated lazily on first use.
+        self._init_pii_caches()
+        # Per-module mapping of class name → ClassDef node, used by
+        # _raw_ast_is_model_subclass to resolve same-module ancestors.
+        self._module_classdefs = {}
+
+    # ------------------------------------------------------------------
+    # AST Visitors
+    # ------------------------------------------------------------------
+
+    @utils.only_required_for_messages(
+        "pii-missing-squelch"
+    )
+    def visit_module(self, node):
+        """Cache source lines and reset all per-module state."""
+        # Reset config caches so options are re-read for each module.
+        self._pii_terms_cache = None
+        self._safe_functions_cache = None
+        self._safe_keys_cache = None
+        self._django_model_bases_cache = None
+        self._module_classdefs = {}
+        try:
+            module_bytes = node.stream().read()
+            encoding = node.file_encoding or "utf-8"
+            self._source_lines = module_bytes.decode(encoding).splitlines()
+        except Exception:  # pylint: disable=broad-except
+            self._source_lines = []
+
+    @utils.only_required_for_messages("pii-missing-squelch")
+    def visit_classdef(self, node):
+        """Index every class definition for same-module ancestry resolution.
+
+        This is required so that ``_raw_ast_is_model_subclass`` can walk the
+        inheritance chain of classes defined in the same module without
+        relying on astroid's import resolution (which requires Django to be
+        installed in the linting environment).
+        """
+        self._module_classdefs[node.name] = node
+
+    @utils.only_required_for_messages("pii-missing-squelch")
+    def visit_call(self, node):
+        """Check logging and print/stdout/stderr calls for unguarded PII."""
+        if self._is_log_call(node):
+            self._check_sink(node, "log call")
+        elif self._is_print_call(node):
+            self._check_sink(node, "print/stdout/stderr")
+
+    @utils.only_required_for_messages("pii-missing-squelch")
+    def visit_raise(self, node):
+        """Check raised exceptions for unguarded PII in their messages.
+
+        Only fires when the raise statement is inside an annotation-eligible
+        Django model method that is not annotated ``.. no_pii:``.
+        Raises outside a Django model (standalone code, module-level) are
+        entirely out of scope.
+        """
+        if not self._requires_squelch_check(node):
+            return
+        if node.exc is None:
+            return
+        exc = node.exc
+        if not isinstance(exc, astroid_nodes.Call):
+            return
+        all_args = list(exc.args) + [kw.value for kw in (exc.keywords or [])]
+        for arg in all_args:
+            pii_term = self._contains_pii(arg)
+            if pii_term:
+                if not self._is_inside_squelch_guard(node):
+                    self.add_message(
+                        "pii-missing-squelch",
+                        node=exc,
+                        args=(pii_term, "raised exception"),
+                    )
+                return  # at most one message per raise
+
+    # ------------------------------------------------------------------
+    # Sink identification helpers
+    # ------------------------------------------------------------------
+
+    def _is_log_call(self, node):
+        """Return True if *node* is a call to a standard logging method."""
+        if not isinstance(node.func, astroid_nodes.Attribute):
+            return False
+        return node.func.attrname in _LOG_METHODS
+
+    def _is_print_call(self, node):
+        """Return True if *node* is a print() or stdout/stderr write() call."""
+        # bare print()
+        if isinstance(node.func, astroid_nodes.Name) and node.func.name == "print":
+            return True
+        # self.stdout.write(...)  /  sys.stdout.write(...)  /  stderr.write(...)
+        if isinstance(node.func, astroid_nodes.Attribute) and node.func.attrname == "write":
+            return True
+        return False
+
+    def _check_sink(self, node, sink_label):
+        """Emit ``pii-missing-squelch`` if any argument of *node* contains PII
+        and the call is not inside a SQUELCH_PII_IN_LOGS guard.
+
+        *sink_label* is a human-readable description of the sink type
+        (e.g. ``'log call'``, ``'print/stdout/stderr'``) included in the
+        emitted message so the developer knows what to fix.
+
+        Squelch checks are ONLY enforced inside Django model classes that do
+        not carry a ``.. no_pii:`` annotation.  Standalone functions and
+        ``.. no_pii:``-annotated models are entirely skipped.
+        """
+        if not self._requires_squelch_check(node):
+            return
+
+        all_args = list(node.args)
+        for kw in node.keywords or []:
+            all_args.append(kw.value)
+        for arg in all_args:
+            pii_term = self._contains_pii(arg)
+            if pii_term:
+                if not self._is_inside_squelch_guard(node):
+                    self.add_message(
+                        "pii-missing-squelch",
+                        node=node,
+                        args=(pii_term, sink_label),
+                    )
+                return  # at most one message per call
+
+    def _requires_squelch_check(self, node):
+        """Return True if *node* is inside an eligible Django model that is
+        NOT annotated with ``.. no_pii:``.
+
+        Scope rules:
+
+        * Inside a Django model annotated ``.. no_pii:``  → **SKIP** (safe model).
+        * Inside a Django model with ``.. pii:`` or no annotation → **CHECK**.
+        * Standalone functions, module-level code, non-model classes → **SKIP**.
+
+        This mirrors the original scope: only Django model methods are subject
+        to squelch-guard enforcement.  Code outside a model is not in scope
+        because it is not subject to OEP-0030 annotation requirements.
+        """
+        current = node.parent
+        while current is not None:
+            if isinstance(current, astroid_nodes.ClassDef):
+                if self._is_annotation_eligible_django_model(current):
+                    # Inside an eligible model — require guard ONLY if not safe.
+                    return not self._class_has_no_pii_annotation(current)
+                # Inside a non-model class — keep walking up.
+            current = current.parent
+        # Not inside any Django model class → out of scope, skip.
+        return False

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -69,20 +69,6 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
             },
         ),
         (
-            "pii-safe-functions",
-            {
-                "default": (
-                    "redact, redact_pii, mask, mask_pii, hash_pii, obfuscate, obfuscate_pii"
-                ),
-                "type": "csv",
-                "metavar": "<comma-separated safe function names>",
-                "help": (
-                    "Functions that safely transform PII. Calls wrapped in one of these "
-                    "functions will not be flagged."
-                ),
-            },
-        ),
-        (
             "pii-safe-key-patterns",
             {
                 "default": (
@@ -142,7 +128,6 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         # Config caches — explicitly initialised here so pylint knows they
         # exist; reset per-module via _init_pii_caches() in visit_module.
         self._pii_terms_cache = None
-        self._safe_functions_cache = None
         self._safe_keys_cache = None
         self._django_model_bases_cache = None
         # Per-module mapping of class name → ClassDef node, used by

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -1,75 +1,145 @@
 """
-PII Missing Squelch Checker — flags log/print/exception calls inside Django
-model methods that expose PII without a SQUELCH_PII_IN_LOGS guard (W7630).
+PII Missing Squelch Checker — flags log/print/exception calls that expose PII
+without a SQUELCH_PII_IN_LOGS guard (W7630).
+
+Checks run across the entire repository, not limited to Django models.
 """
 
 from astroid import nodes as astroid_nodes
 from pylint.checkers import BaseChecker, utils
 
 from .common import BASE_ID, check_visitors
-from ._pii_common import _LOG_METHODS, PiiConfigMixin
+from ._pii_common import PiiConfigMixin
+
+
+# ---------------------------------------------------------------------------
+# Squelch-specific constants
+# ---------------------------------------------------------------------------
+
+# Logging method names recognised as PII output sinks.
+_LOG_METHODS = frozenset({
+    "debug", "info", "warning", "warn", "error",
+    "critical", "exception", "log",
+})
+
+# Default name of the feature-flag that gates PII-inclusive output.
+_DEFAULT_SQUELCH_FLAG = "SQUELCH_PII_IN_LOGS"
 
 
 def register_checkers(linter):
-    """
-    Register the PII missing-squelch checker.
-    """
+    """Register the PII missing-squelch checker."""
     linter.register_checker(PiiMissingSquelchChecker(linter))
 
 
 @check_visitors
 class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
     """
-    Flags unguarded PII in log/print/exception calls inside Django model methods.
+    Flags unguarded PII in log/print/exception calls across all Python code.
     """
 
     name = "pii-missing-squelch"
 
+    # Message definitions — one symbol covers log + print + exception
     msgs = {
         ("W%d30" % BASE_ID): (
             "PII term '%s' exposed in %s without a SQUELCH_PII_IN_LOGS guard. "
             "Wrap with: if not SQUELCH_PII_IN_LOGS: ...",
             "pii-missing-squelch",
-            "A log call, print/stdout/stderr write, or raised exception inside a "
-            "Django model method exposes likely PII without a SQUELCH_PII_IN_LOGS "
-            "guard. Wrap the offending line with: if not SQUELCH_PII_IN_LOGS: ...",
+            "A log call, print/stdout/stderr write, or raised exception exposes "
+            "likely PII without a SQUELCH_PII_IN_LOGS "
+            "guard.  Wrap the offending line with: if not SQUELCH_PII_IN_LOGS: ...",
         ),
     }
 
+    # Configurable options
+    # NOTE: All shared PII options are declared here so they appear in
+    #       linter.config before PiiAnnotationChecker reads them via getattr().
+    options = (
+        (
+            "pii-terms",
+            {
+                "default": (
+                    # Conservative MVP defaults: high-sensitivity, commonly-exposed terms.
+                    # Repositories can expand this list via pylintrc [PII] pii-terms.
+                    "email, username, password"
+                ),
+                "type": "csv",
+                "metavar": "<comma-separated PII terms>",
+                "help": (
+                    "Comma-separated OEP-0030 PII identifier substrings matched against "
+                    "variable names and attribute accesses passed to log/print/exception "
+                    "sinks.  String literals are NOT matched — only variable/attribute "
+                    "references."
+                ),
+            },
+        ),
+        (
+            "pii-safe-key-patterns",
+            {
+                "default": (
+                    "user_id, course_id, thread_id, comment_id, block_id, "
+                    "usage_id, usage_key, anonymous_user_id, service_username, "
+                    "email_enabled, email_sent_on, email_scheduled, "
+                    "require_course_email_auth, reported_content_email_notifications, "
+                    "email_reminder_sent, eligibility_email_message, receipt_email_message, "
+                    "proctoring_escalation_email, email_cadence, "
+                    "attr_full_name, default_full_name, attr_first_name, default_first_name, "
+                    "attr_last_name, default_last_name, attr_username, default_username, "
+                    "attr_email, default_email, skip_email_verification, location, _location, "
+                    "example_full_name"
+                ),
+                "type": "csv",
+                "metavar": "<comma-separated safe key patterns>",
+                "help": (
+                    "Exact identifiers that look like PII terms but are approved as "
+                    "non-sensitive (e.g. surrogate keys, flag fields).  Exact match only."
+                ),
+            },
+        ),
+        (
+            "pii-squelch-flag",
+            {
+                "default": _DEFAULT_SQUELCH_FLAG,
+                "type": "string",
+                "metavar": "<flag name>",
+                "help": (
+                    "Name of the feature toggle that gates PII-inclusive log/print/exception "
+                    "output.  PII sinks must be inside an if-block that tests this flag. "
+                    "Default: SQUELCH_PII_IN_LOGS."
+                ),
+            },
+        ),
+        (
+            "pii-django-model-bases",
+            {
+                "default": "Model",
+                "type": "csv",
+                "metavar": "<comma-separated base class names>",
+                "help": (
+                    "Base class *names* that identify a Django model.  Used by "
+                    "pii-invalid-no-pii-annotation (W7633).  Default: Model."
+                ),
+            },
+        ),
+    )
+
+    # Lifecycle
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._source_lines = []           # source lines for comment-annotation lookup
-        # Config caches — reset each module via _init_pii_caches() in visit_module.
+        # Config caches — reset per-module via _init_pii_caches() in visit_module.
         self._pii_terms_cache = None
         self._safe_keys_cache = None
-        self._django_model_bases_cache = None
-        self._module_classdefs = {}       # class name → ClassDef for BFS ancestry
 
+    # AST Visitors
     @utils.only_required_for_messages("pii-missing-squelch")
-    def visit_module(self, node):
-        """
-        Reset all per-module state and cache source lines for annotation lookup.
-        """
+    def visit_module(self, node):  # pylint: disable=unused-argument
+        """Reset per-module config caches."""
         self._init_pii_caches()
-        self._module_classdefs = {}
-        try:
-            module_bytes = node.stream().read()
-            encoding = node.file_encoding or "utf-8"
-            self._source_lines = module_bytes.decode(encoding).splitlines()
-        except Exception:  # pylint: disable=broad-except
-            self._source_lines = []
-
-    @utils.only_required_for_messages("pii-missing-squelch")
-    def visit_classdef(self, node):
-        """
-        Index class definitions for same-module ancestry resolution.
-        """
-        self._module_classdefs[node.name] = node
 
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_call(self, node):
         """
-        Check log and print/stdout/stderr calls for unguarded PII.
+        Check logging and print/stdout/stderr calls for unguarded PII.
         """
         if self._is_log_call(node):
             self._check_sink(node, "log call")
@@ -79,10 +149,12 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_raise(self, node):
         """
-        Check raised exceptions for unguarded PII.
+        Check raised exceptions for unguarded PII in their messages.
         """
+        if node.exc is None:
+            return
         exc = node.exc
-        if not self._requires_squelch_check(node) or exc is None or not isinstance(exc, astroid_nodes.Call):
+        if not isinstance(exc, astroid_nodes.Call):
             return
         all_args = list(exc.args) + [kw.value for kw in (exc.keywords or [])]
         for arg in all_args:
@@ -96,9 +168,10 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                     )
                 return  # at most one message per raise
 
+    # Sink identification helpers
     def _is_log_call(self, node):
         """
-        Return True if *node* is a standard logging method call.
+        Return True if *node* is a call to a standard logging method.
         """
         if not isinstance(node.func, astroid_nodes.Attribute):
             return False
@@ -106,29 +179,24 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
 
     def _is_print_call(self, node):
         """
-        Return True if *node* is a print() or sys.stdout/stderr write() call.
+        Return True if *node* is a print() or stdout/stderr write() call.
         """
         # bare print()
         if isinstance(node.func, astroid_nodes.Name) and node.func.name == "print":
             return True
         # sys.stdout.write(...) / sys.stderr.write(...) / self.stdout.write(...)
-        if (
-            isinstance(node.func, astroid_nodes.Attribute)
-            and node.func.attrname == "write"
-            and isinstance(node.func.expr, astroid_nodes.Attribute)
-            and node.func.expr.attrname in ("stdout", "stderr")
-        ):
+        if isinstance(node.func, astroid_nodes.Attribute) and node.func.attrname == "write":
             return True
         return False
 
     def _check_sink(self, node, sink_label):
         """
-        Emit ``pii-missing-squelch`` if *node* has a PII argument outside a squelch guard.
+        Emit ``pii-missing-squelch`` if any argument of *node* contains PII
+        and the call is not inside a SQUELCH_PII_IN_LOGS guard.
         """
-        if not self._requires_squelch_check(node):
-            return
-
-        all_args = list(node.args) + [kw.value for kw in (node.keywords or [])]
+        all_args = list(node.args)
+        for kw in node.keywords or []:
+            all_args.append(kw.value)
         for arg in all_args:
             pii_term = self._contains_pii(arg)
             if pii_term:
@@ -138,19 +206,158 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                         node=node,
                         args=(pii_term, sink_label),
                     )
-                return  # at most one message per call
+                return  # at most one message per call-site
 
-    def _requires_squelch_check(self, node):
+    # PII detection helpers
+    def _contains_pii(self, node):
         """
-        Return True if *node* is inside an eligible Django model without ``.. no_pii:``.
+        Recursively inspect *node* and return the first PII term found, or None.
+
+        Checked node types:
+        - ``Name``: plain variable reference — check the variable name.
+        - ``Attribute``: ``self.email`` — check the attribute name only.
+        - ``Call``: recurse into positional args and keyword values.
+        - ``JoinedStr`` (f-string): recurse into each ``FormattedValue`` child.
+        - ``BinOp``: recurse left and right (catches ``"email: %s" % email``).
+        - ``Tuple / List / Set``: recurse into each element.
+        - ``Dict``: recurse into values (keys are typically string literals).
+        - ``Const`` (string literal): never flagged — format strings are safe.
         """
+        if node is None:
+            return None
+
+        # A plain name: check it directly.
+        if isinstance(node, astroid_nodes.Name):
+            if self._is_pii_name(node.name):
+                return node.name
+
+        # An attribute access (e.g. user.email, request.user.username).
+        elif isinstance(node, astroid_nodes.Attribute):
+            if self._is_pii_name(node.attrname):
+                return node.attrname
+
+        # A call: recurse into args and keyword values.
+        elif isinstance(node, astroid_nodes.Call):
+            for arg in node.args:
+                found = self._contains_pii(arg)
+                if found:
+                    return found
+            for kw in node.keywords or []:
+                found = self._contains_pii(kw.value)
+                if found:
+                    return found
+
+        # f-string: recurse into each interpolated {expr}.
+        elif isinstance(node, astroid_nodes.JoinedStr):
+            for child in node.values:
+                if isinstance(child, astroid_nodes.FormattedValue):
+                    found = self._contains_pii(child.value)
+                    if found:
+                        return found
+
+        # Binary op (e.g. "hello " + username  or  "email: %s" % email).
+        elif isinstance(node, astroid_nodes.BinOp):
+            return self._contains_pii(node.left) or self._contains_pii(node.right)
+
+        # Tuple / List / Set: recurse into each element.
+        elif isinstance(node, (astroid_nodes.Tuple, astroid_nodes.List, astroid_nodes.Set)):
+            for elt in node.elts:
+                found = self._contains_pii(elt)
+                if found:
+                    return found
+
+        # Dict: recurse into values (keys are usually string identifiers).
+        elif isinstance(node, astroid_nodes.Dict):
+            for _key, value in node.items:
+                found = self._contains_pii(value)
+                if found:
+                    return found
+
+        return None
+
+    # Squelch-guard helpers
+    def _squelch_flag(self):
+        """Return the configured squelch feature-flag name."""
+        return getattr(self.linter.config, "pii_squelch_flag", _DEFAULT_SQUELCH_FLAG)
+
+    def _test_references_flag(self, test, flag):
+        """
+        Return True if the AST condition *test* references *flag*.
+
+        Recognised guard patterns:
+        1. ``getattr(settings, 'SQUELCH_PII_IN_LOGS', False)``  (Call → getattr)
+        2. ``settings.SQUELCH_PII_IN_LOGS``                     (Attribute)
+        3. ``settings.FEATURES.get('SQUELCH_PII_IN_LOGS')``     (Call → .get)
+        4. ``settings.FEATURES['SQUELCH_PII_IN_LOGS']``         (Subscript)
+        5. ``SQUELCH_PII_IN_LOGS.is_enabled()``                 (Call → method)
+        6. ``SQUELCH_PII_IN_LOGS``                              (bare Name)
+        7. ``not SQUELCH_PII_IN_LOGS``  (and all negated forms) (UnaryOp)
+        """
+        # Pattern 1: getattr(settings, 'FLAG', False)
+        if (isinstance(test, astroid_nodes.Call)
+                and isinstance(test.func, astroid_nodes.Name)
+                and test.func.name == "getattr"
+                and len(test.args) >= 2):
+            second_arg = test.args[1]
+            if isinstance(second_arg, astroid_nodes.Const) and second_arg.value == flag:
+                return True
+
+        # Pattern 2: settings.FLAG  (Attribute)
+        if isinstance(test, astroid_nodes.Attribute) and test.attrname == flag:
+            return True
+
+        # Pattern 3: settings.FEATURES.get('FLAG')
+        if (isinstance(test, astroid_nodes.Call)
+                and isinstance(test.func, astroid_nodes.Attribute)
+                and test.func.attrname == "get"
+                and test.args
+                and isinstance(test.args[0], astroid_nodes.Const)
+                and test.args[0].value == flag):
+            return True
+
+        # Pattern 4: settings.FEATURES['FLAG']  (Subscript)
+        if isinstance(test, astroid_nodes.Subscript):
+            slc = test.slice
+            # Compatibility: older astroid versions wrap slices in an Index node.
+            _IndexNode = getattr(astroid_nodes, "Index", None)
+            if _IndexNode is not None and isinstance(slc, _IndexNode):  # pylint: disable=isinstance-second-argument-not-valid-type
+                slc = slc.value
+            if isinstance(slc, astroid_nodes.Const) and slc.value == flag:
+                return True
+
+        # Pattern 5: FLAG.is_enabled() / FLAG.is_active() / FLAG.is_waffle_flag_active()
+        if (isinstance(test, astroid_nodes.Call)
+                and isinstance(test.func, astroid_nodes.Attribute)
+                and test.func.attrname in ("is_enabled", "is_active", "is_waffle_flag_active")):
+            if self._test_references_flag(test.func.expr, flag):
+                return True
+
+        # Pattern 6: bare Name
+        if isinstance(test, astroid_nodes.Name) and test.name == flag:
+            return True
+
+        # Pattern 7 & all negated forms: not <expr>
+        if isinstance(test, astroid_nodes.UnaryOp) and test.op == "not":
+            return self._test_references_flag(test.operand, flag)
+
+        return False
+
+    def _is_inside_squelch_guard(self, node):
+        """
+        Return True if *node* is nested inside any branch of an if-statement
+        whose condition tests the squelch flag.
+
+        Any if-block referencing the flag — ``if FLAG:``, ``if not FLAG:``,
+        or any ``settings.*`` / ``getattr`` / method-call equivalent — counts
+        as a guard for both the if-body and the else-body.
+        """
+        flag = self._squelch_flag()
         current = node.parent
         while current is not None:
-            if isinstance(current, astroid_nodes.ClassDef):
-                if self._is_annotation_eligible_django_model(current):
-                    # Require squelch guard only when the model lacks .. no_pii:.
-                    return not self._class_has_no_pii_annotation(current)
-                # Inside a non-model class — keep walking up.
+            if isinstance(current, astroid_nodes.Module):
+                break
+            if isinstance(current, astroid_nodes.If):
+                if self._test_references_flag(current.test, flag):
+                    return True
             current = current.parent
-        # Not inside any Django model class → out of scope, skip.
         return False

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -46,17 +46,17 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                     # Curated OEP-0030 PII identifiers. Generic terms (name, ip, sex,
                     # image, video, title, bio, social, website) excluded to avoid false
                     # positives; add them back via this option in your pylintrc if needed.
-                    "email,secondary_email,"
-                    "username,retired_username,"
-                    "password,"
-                    "full_name,first_name,last_name,"
-                    "phone,phone_number,"
-                    "birth_date,"
-                    "ip_address,"
-                    "location,address,mailing_address,"
-                    "gender,"
-                    "profile_image,"
-                    "job_title,"
+                    "email, secondary_email, "
+                    "username, retired_username, "
+                    "password, "
+                    "full_name, first_name, last_name, "
+                    "phone, phone_number, "
+                    "birth_date, "
+                    "ip_address, "
+                    "location, address, mailing_address, "
+                    "gender, "
+                    "profile_image, "
+                    "job_title, "
                     "social_link"
                 ),
                 "type": "csv",
@@ -72,7 +72,7 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
             "pii-safe-functions",
             {
                 "default": (
-                    "redact,redact_pii,mask,mask_pii,hash_pii,obfuscate,obfuscate_pii"
+                    "redact, redact_pii, mask, mask_pii, hash_pii, obfuscate, obfuscate_pii"
                 ),
                 "type": "csv",
                 "metavar": "<comma-separated safe function names>",
@@ -86,15 +86,15 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
             "pii-safe-key-patterns",
             {
                 "default": (
-                    "user_id,course_id,thread_id,comment_id,block_id,"
-                    "usage_id,usage_key,anonymous_user_id,service_username,"
-                    "email_enabled,email_sent_on,email_scheduled,"
-                    "require_course_email_auth,reported_content_email_notifications,"
-                    "email_reminder_sent,eligibility_email_message,receipt_email_message,"
-                    "proctoring_escalation_email,email_cadence,"
-                    "attr_full_name,default_full_name,attr_first_name,default_first_name,"
-                    "attr_last_name,default_last_name,attr_username,default_username,"
-                    "attr_email,default_email,skip_email_verification,location,_location,"
+                    "user_id, course_id, thread_id, comment_id, block_id, "
+                    "usage_id, usage_key, anonymous_user_id, service_username, "
+                    "email_enabled, email_sent_on, email_scheduled, "
+                    "require_course_email_auth, reported_content_email_notifications, "
+                    "email_reminder_sent, eligibility_email_message, receipt_email_message, "
+                    "proctoring_escalation_email, email_cadence, "
+                    "attr_full_name, default_full_name, attr_first_name, default_first_name, "
+                    "attr_last_name, default_last_name, attr_username, default_username, "
+                    "attr_email, default_email, skip_email_verification, location, _location, "
                     "example_full_name"
                 ),
                 "type": "csv",

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -226,52 +226,53 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         if node is None:
             return None
 
-        # A plain name: check it directly.
-        if isinstance(node, astroid_nodes.Name):
-            if self._is_pii_name(node.name):
-                return node.name
+        match node:
+            # A plain name: check it directly.
+            case astroid_nodes.Name():
+                if self._is_pii_name(node.name):
+                    return node.name
 
-        # An attribute access (e.g. user.email, request.user.username).
-        elif isinstance(node, astroid_nodes.Attribute):
-            if self._is_pii_name(node.attrname):
-                return node.attrname
+            # An attribute access (e.g. user.email, request.user.username).
+            case astroid_nodes.Attribute():
+                if self._is_pii_name(node.attrname):
+                    return node.attrname
 
-        # A call: recurse into args and keyword values.
-        elif isinstance(node, astroid_nodes.Call):
-            for arg in node.args:
-                found = self._contains_pii(arg)
-                if found:
-                    return found
-            for kw in node.keywords or []:
-                found = self._contains_pii(kw.value)
-                if found:
-                    return found
-
-        # f-string: recurse into each interpolated {expr}.
-        elif isinstance(node, astroid_nodes.JoinedStr):
-            for child in node.values:
-                if isinstance(child, astroid_nodes.FormattedValue):
-                    found = self._contains_pii(child.value)
+            # A call: recurse into args and keyword values.
+            case astroid_nodes.Call():
+                for arg in node.args:
+                    found = self._contains_pii(arg)
+                    if found:
+                        return found
+                for kw in node.keywords or []:
+                    found = self._contains_pii(kw.value)
                     if found:
                         return found
 
-        # Binary op (e.g. "hello " + username  or  "email: %s" % email).
-        elif isinstance(node, astroid_nodes.BinOp):
-            return self._contains_pii(node.left) or self._contains_pii(node.right)
+            # f-string: recurse into each interpolated {expr}.
+            case astroid_nodes.JoinedStr():
+                for child in node.values:
+                    if isinstance(child, astroid_nodes.FormattedValue):
+                        found = self._contains_pii(child.value)
+                        if found:
+                            return found
 
-        # Tuple / List / Set: recurse into each element.
-        elif isinstance(node, (astroid_nodes.Tuple, astroid_nodes.List, astroid_nodes.Set)):
-            for elt in node.elts:
-                found = self._contains_pii(elt)
-                if found:
-                    return found
+            # Binary op (e.g. "hello " + username  or  "email: %s" % email).
+            case astroid_nodes.BinOp():
+                return self._contains_pii(node.left) or self._contains_pii(node.right)
 
-        # Dict: recurse into values (keys are usually string identifiers).
-        elif isinstance(node, astroid_nodes.Dict):
-            for _key, value in node.items:
-                found = self._contains_pii(value)
-                if found:
-                    return found
+            # Tuple / List / Set: recurse into each element.
+            case astroid_nodes.Tuple() | astroid_nodes.List() | astroid_nodes.Set():
+                for elt in node.elts:
+                    found = self._contains_pii(elt)
+                    if found:
+                        return found
+
+            # Dict: recurse into values (keys are usually string identifiers).
+            case astroid_nodes.Dict():
+                for _key, value in node.items:
+                    found = self._contains_pii(value)
+                    if found:
+                        return found
 
         return None
 
@@ -310,10 +311,10 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         if (isinstance(test, astroid_nodes.Call)
                 and isinstance(test.func, astroid_nodes.Attribute)
                 and test.func.attrname == "get"
-                and test.args
-                and isinstance(test.args[0], astroid_nodes.Const)
-                and test.args[0].value == flag):
-            return True
+                and test.args):
+            first_arg = test.args[0]
+            if isinstance(first_arg, astroid_nodes.Const) and first_arg.value == flag:
+                return True
 
         # Pattern 4: settings.FEATURES['FLAG']  (Subscript)
         if isinstance(test, astroid_nodes.Subscript):

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -49,32 +49,33 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
             "pii-terms",
             {
                 "default": (
-                    # OEP-0030 PII fields (https://open-edx-proposals.readthedocs.io/en/latest/
-                    # architectural-decisions/oep-0030-arch-pii-markup-and-auditing.html)
-                    "email,secondary_email,"           # email_address
-                    "username,retired_username,"       # username
-                    "password,"                        # password
-                    "name,full_name,first_name,last_name,"  # name
-                    "phone,phone_number,"              # phone_number
-                    "birth_date,"                      # birth_date
-                    "ip,ip_address,"                   # ip
-                    "location,address,mailing_address,"  # location
-                    "gender,sex,"                      # gender / sex
-                    "bio,biography,"                   # biography
-                    "profile_image,image,video,"       # image / video
-                    "title,job_title,"                 # job title
-                    "social,website"                   # external_service (social media, website)
+                    # Curated OEP-0030 PII identifiers. Generic terms (name, ip, sex,
+                    # image, video, title, bio, social, website) excluded to avoid false
+                    # positives; add them back via this option in your pylintrc if needed.
+                    "email,secondary_email,"
+                    "username,retired_username,"
+                    "password,"
+                    "full_name,first_name,last_name,"
+                    "phone,phone_number,"
+                    "birth_date,"
+                    "ip_address,"
+                    "location,address,mailing_address,"
+                    "gender,"
+                    "profile_image,"
+                    "job_title,"
+                    "social_link"
                 ),
                 "type": "csv",
                 "metavar": "<comma-separated PII terms>",
                 "help": (
-                    "Comma-separated list of identifier substrings treated as PII per OEP-0030. "
-                    "Matches variable names and attribute accesses passed to log/print/exception "
-                    "sinks. String literals in log messages are NOT matched — only actual PII "
-                    "variable and attribute references are flagged."
+                    "Comma-separated OEP-0030 PII identifier substrings matched against variable "
+                    "names and attribute accesses passed to log/print/exception sinks. "
+                    "String literals are NOT matched — only actual variable/attribute references."
                 ),
             },
         ),
+
+
         (
             "pii-safe-functions",
             {

--- a/edx_lint/pylint/pii_squelch_check.py
+++ b/edx_lint/pylint/pii_squelch_check.py
@@ -17,17 +17,13 @@ def register_checkers(linter):
 
 @check_visitors
 class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
-    """Flags unguarded PII in log/print/exception calls inside Django model methods.
-
-    Fires ``pii-missing-squelch`` (W7630). Skips .. no_pii: models, abstract/proxy
-    models, standalone functions, and any call wrapped in a SQUELCH_PII_IN_LOGS guard.
+    """
+    Flags unguarded PII in log/print/exception calls inside Django model methods.
     """
 
     name = "pii-missing-squelch"
 
-    # ------------------------------------------------------------------
     # Message definitions — one symbol covers log + print + exception
-    # ------------------------------------------------------------------
     msgs = {
         ("W%d30" % BASE_ID): (
             "PII term '%s' exposed in %s without a SQUELCH_PII_IN_LOGS guard. "
@@ -39,11 +35,9 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         ),
     }
 
-    # ------------------------------------------------------------------
     # Configurable options
     # NOTE: All shared PII options are defined here.  PiiAnnotationChecker
     #       reads them from linter.config via getattr() with safe defaults.
-    # ------------------------------------------------------------------
     options = (
         (
             "pii-terms",
@@ -142,10 +136,7 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         ),
     )
 
-    # ------------------------------------------------------------------
     # Lifecycle
-    # ------------------------------------------------------------------
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Cached per-module source lines for comment-style annotation lookup.
@@ -160,10 +151,7 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         # _raw_ast_is_model_subclass to resolve same-module ancestors.
         self._module_classdefs = {}
 
-    # ------------------------------------------------------------------
     # AST Visitors
-    # ------------------------------------------------------------------
-
     @utils.only_required_for_messages(
         "pii-missing-squelch"
     )
@@ -181,18 +169,16 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
 
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_classdef(self, node):
-        """Index every class definition for same-module ancestry resolution.
-
-        This is required so that ``_raw_ast_is_model_subclass`` can walk the
-        inheritance chain of classes defined in the same module without
-        relying on astroid's import resolution (which requires Django to be
-        installed in the linting environment).
+        """
+        Index every class definition for same-module ancestry resolution.
         """
         self._module_classdefs[node.name] = node
 
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_call(self, node):
-        """Check logging and print/stdout/stderr calls for unguarded PII."""
+        """
+        Check logging and print/stdout/stderr calls for unguarded PII.
+        """
         if self._is_log_call(node):
             self._check_sink(node, "log call")
         elif self._is_print_call(node):
@@ -200,12 +186,8 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
 
     @utils.only_required_for_messages("pii-missing-squelch")
     def visit_raise(self, node):
-        """Check raised exceptions for unguarded PII in their messages.
-
-        Only fires when the raise statement is inside an annotation-eligible
-        Django model method that is not annotated ``.. no_pii:``.
-        Raises outside a Django model (standalone code, module-level) are
-        entirely out of scope.
+        """
+        Check raised exceptions for unguarded PII in their messages.
         """
         if not self._requires_squelch_check(node):
             return
@@ -226,18 +208,19 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                     )
                 return  # at most one message per raise
 
-    # ------------------------------------------------------------------
     # Sink identification helpers
-    # ------------------------------------------------------------------
-
     def _is_log_call(self, node):
-        """Return True if *node* is a call to a standard logging method."""
+        """
+        Return True if *node* is a call to a standard logging method.
+        """
         if not isinstance(node.func, astroid_nodes.Attribute):
             return False
         return node.func.attrname in _LOG_METHODS
 
     def _is_print_call(self, node):
-        """Return True if *node* is a print() or stdout/stderr write() call."""
+        """
+        Return True if *node* is a print() or stdout/stderr write() call.
+        """
         # bare print()
         if isinstance(node.func, astroid_nodes.Name) and node.func.name == "print":
             return True
@@ -247,16 +230,9 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
         return False
 
     def _check_sink(self, node, sink_label):
-        """Emit ``pii-missing-squelch`` if any argument of *node* contains PII
+        """
+        Emit ``pii-missing-squelch`` if any argument of *node* contains PII
         and the call is not inside a SQUELCH_PII_IN_LOGS guard.
-
-        *sink_label* is a human-readable description of the sink type
-        (e.g. ``'log call'``, ``'print/stdout/stderr'``) included in the
-        emitted message so the developer knows what to fix.
-
-        Squelch checks are ONLY enforced inside Django model classes that do
-        not carry a ``.. no_pii:`` annotation.  Standalone functions and
-        ``.. no_pii:``-annotated models are entirely skipped.
         """
         if not self._requires_squelch_check(node):
             return
@@ -276,18 +252,9 @@ class PiiMissingSquelchChecker(PiiConfigMixin, BaseChecker):
                 return  # at most one message per call
 
     def _requires_squelch_check(self, node):
-        """Return True if *node* is inside an eligible Django model that is
+        """
+        Return True if *node* is inside an eligible Django model that is
         NOT annotated with ``.. no_pii:``.
-
-        Scope rules:
-
-        * Inside a Django model annotated ``.. no_pii:``  → **SKIP** (safe model).
-        * Inside a Django model with ``.. pii:`` or no annotation → **CHECK**.
-        * Standalone functions, module-level code, non-model classes → **SKIP**.
-
-        This mirrors the original scope: only Django model methods are subject
-        to squelch-guard enforcement.  Code outside a model is not in scope
-        because it is not subject to OEP-0030 annotation requirements.
         """
         current = node.parent
         while current is not None:

--- a/edx_lint/pylint/plugin.py
+++ b/edx_lint/pylint/plugin.py
@@ -5,7 +5,6 @@ will register them with pylint.
 """
 
 from edx_lint.pylint import (
-    _pii_common,
     annotations_check,
     getattr_check,
     i18n_check,
@@ -24,7 +23,6 @@ MODS = [
     getattr_check,
     i18n_check,
     module_trace,
-    _pii_common,
     pii_squelch_check,
     pii_annotation_check,
     range_check,

--- a/edx_lint/pylint/plugin.py
+++ b/edx_lint/pylint/plugin.py
@@ -2,6 +2,19 @@
 
 This module imports all our plugins, and creates the register function that
 will register them with pylint.
+
+PII checking is split into two separate checkers:
+
+* ``pii_squelch_check`` — ``PiiMissingSquelchChecker`` (checker name:
+  ``pii-missing-squelch``) handles the single missing-squelch-guard rule
+  (also named ``pii-missing-squelch``).
+  It also owns all shared PII options (``pii-terms``, ``pii-safe-functions``,
+  ``pii-safe-key-patterns``, ``pii-squelch-flag``, ``pii-django-model-bases``).
+
+* ``pii_annotation_check`` — ``PiiAnnotationChecker`` (checker name:
+  ``pii-annotation-checker``) handles the ``pii-invalid-no-pii-annotation``
+  rule.  It reads shared options from the linter config populated by the
+  squelch checker above, so registration order matters: squelch first.
 """
 
 from edx_lint.pylint import (
@@ -9,6 +22,8 @@ from edx_lint.pylint import (
     getattr_check,
     i18n_check,
     module_trace,
+    pii_squelch_check,
+    pii_annotation_check,
     range_check,
     super_check,
     layered_test_check,
@@ -21,6 +36,11 @@ MODS = [
     getattr_check,
     i18n_check,
     module_trace,
+    # pii_squelch_check MUST come before pii_annotation_check so that the
+    # shared PII options are registered in linter.config before the annotation
+    # checker's _ensure_config_cached() reads them.
+    pii_squelch_check,
+    pii_annotation_check,
     range_check,
     super_check,
     layered_test_check,

--- a/edx_lint/pylint/plugin.py
+++ b/edx_lint/pylint/plugin.py
@@ -2,19 +2,6 @@
 
 This module imports all our plugins, and creates the register function that
 will register them with pylint.
-
-PII checking is split into two separate checkers:
-
-* ``pii_squelch_check`` — ``PiiMissingSquelchChecker`` (checker name:
-  ``pii-missing-squelch``) handles the single missing-squelch-guard rule
-  (also named ``pii-missing-squelch``).
-  It also owns all shared PII options (``pii-terms``, ``pii-safe-functions``,
-  ``pii-safe-key-patterns``, ``pii-squelch-flag``, ``pii-django-model-bases``).
-
-* ``pii_annotation_check`` — ``PiiAnnotationChecker`` (checker name:
-  ``pii-annotation-checker``) handles the ``pii-invalid-no-pii-annotation``
-  rule.  It reads shared options from the linter config populated by the
-  squelch checker above, so registration order matters: squelch first.
 """
 
 from edx_lint.pylint import (

--- a/edx_lint/pylint/plugin.py
+++ b/edx_lint/pylint/plugin.py
@@ -5,6 +5,7 @@ will register them with pylint.
 """
 
 from edx_lint.pylint import (
+    _pii_common,
     annotations_check,
     getattr_check,
     i18n_check,
@@ -23,9 +24,7 @@ MODS = [
     getattr_check,
     i18n_check,
     module_trace,
-    # pii_squelch_check MUST come before pii_annotation_check so that the
-    # shared PII options are registered in linter.config before the annotation
-    # checker's _ensure_config_cached() reads them.
+    _pii_common,
     pii_squelch_check,
     pii_annotation_check,
     range_check,

--- a/test/plugins/test_pii_annotation_check.py
+++ b/test/plugins/test_pii_annotation_check.py
@@ -1,0 +1,276 @@
+"""Tests for pii_annotation_check.py (PiiAnnotationChecker).
+
+Covers the ``pii-invalid-no-pii-annotation`` rule (W7633) emitted by the
+``pii-annotation-checker`` checker.
+
+This rule fires when a concrete (non-abstract, non-proxy) Django model class
+is annotated with ``.. no_pii:`` yet still contains fields or instance
+attributes whose names match the configured PII terms.
+
+Message format produced by run_pylint:
+    "{line_marker}:{symbol}:{message_text}"
+
+e.g.  "A:pii-invalid-no-pii-annotation:Django model 'Profile' is annotated ..."
+
+We test for exact symbol presence using substring matching on the
+marker:symbol prefix.
+"""
+
+from .pylint_test import run_pylint
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ANN_ID = "pii-invalid-no-pii-annotation"
+
+
+def _run(source):
+    """Run pylint checking only pii-invalid-no-pii-annotation."""
+    return run_pylint(source, _ANN_ID)
+
+
+def _has(messages, marker, symbol):
+    """Return True if messages contains one with the given marker and symbol."""
+    prefix = f"{marker}:{symbol}:"
+    return any(m.startswith(prefix) for m in messages)
+
+
+# ===========================================================================
+# pii-invalid-no-pii-annotation: basic detection
+# ===========================================================================
+
+
+def test_no_pii_docstring_with_pii_field():
+    """Django model with ``.. no_pii:`` docstring and a PII field fires on the class line."""
+    source = """\
+        class LearnerProfile(Model):                    #=A
+            '''
+            .. no_pii: Stores only course metadata.
+            '''
+            course_id = None
+            email = None
+    """
+    messages = _run(source)
+    assert _has(messages, "A", _ANN_ID)
+    assert any("email" in m for m in messages)
+
+
+def test_no_pii_comment_above_class():
+    """``# .. no_pii:`` comment above a Django model with PII field fires."""
+    source = """\
+        # .. no_pii:
+        class CourseEnrollment(Model):                  #=A
+            course_id = None
+            username = None
+    """
+    messages = _run(source)
+    assert _has(messages, "A", _ANN_ID)
+    assert any("username" in m for m in messages)
+
+
+def test_no_pii_multiple_pii_fields_single_message():
+    """Multiple PII fields on a Django model produce exactly one message listing all."""
+    source = """\
+        class Profile(Model):                           #=A
+            '''.. no_pii:'''
+            email = None
+            username = None
+            phone_number = None
+    """
+    messages = _run(source)
+    assert len(messages) == 1
+    msg = list(messages)[0]
+    assert "email" in msg
+    assert "username" in msg
+    assert "phone_number" in msg
+
+
+def test_no_pii_with_only_safe_fields_ok():
+    """Django model with ``.. no_pii:`` and only safe surrogate keys does not fire."""
+    source = """\
+        class Enrollment(Model):
+            '''.. no_pii:'''
+            course_id = None
+            user_id = None
+            block_id = None
+    """
+    messages = _run(source)
+    assert not messages
+
+
+def test_no_pii_with_non_pii_fields_ok():
+    """Django model with ``.. no_pii:`` and genuinely non-PII fields is fine."""
+    source = """\
+        class CourseGrade(Model):
+            '''.. no_pii:'''
+            is_passing = True
+            percent = 0.0
+            created = None
+    """
+    messages = _run(source)
+    assert not messages
+
+
+def test_class_without_annotation_not_checked():
+    """A Django model with PII fields but NO annotation is out of scope for this rule."""
+    source = """\
+        class BadModel(Model):
+            email = None
+            username = None
+    """
+    messages = _run(source)
+    assert not messages
+
+
+def test_pii_annotated_class_not_checked():
+    """A Django model with ``.. pii:`` annotation and PII fields is correct — no warning."""
+    source = """\
+        class UserProfile(Model):
+            '''
+            .. pii: Stores learner email.
+            .. pii_types: email_address
+            .. pii_retirement: local_api
+            '''
+            email = None
+    """
+    messages = _run(source)
+    assert not messages
+
+
+def test_no_pii_instance_attr_in_method_flagged():
+    """``self.phone_number = ...`` inside __init__ of a Django model is caught."""
+    source = """\
+        class UserData(Model):                          #=A
+            '''.. no_pii:'''
+            def __init__(self, data):
+                self.phone_number = data.phone
+                self.is_active = data.active
+    """
+    messages = _run(source)
+    assert _has(messages, "A", _ANN_ID)
+    assert any("self.phone_number" in m for m in messages)
+
+
+def test_no_pii_annotated_assignment_flagged():
+    """``email: str = ""`` (AnnAssign) on a Django model is caught."""
+    source = """\
+        class Profile(Model):                           #=A
+            '''.. no_pii:'''
+            email: str = ""
+    """
+    messages = _run(source)
+    assert _has(messages, "A", _ANN_ID)
+
+
+def test_no_pii_inline_disable_suppresses():
+    """``# pylint: disable=pii-invalid-no-pii-annotation`` suppresses the rule."""
+    source = """\
+        class Profile(Model):  # pylint: disable=pii-invalid-no-pii-annotation
+            '''.. no_pii:'''
+            email = None
+    """
+    messages = _run(source)
+    assert not messages
+
+
+def test_decorator_between_comment_annotation_and_class():
+    """A decorator between the ``# .. no_pii:`` comment and a Django model class is still detected."""
+    source = """\
+        # .. no_pii:
+        @some_decorator
+        class Enrollment(Model):                        #=A
+            username = None
+    """
+    messages = _run(source)
+    assert _has(messages, "A", _ANN_ID)
+
+
+# ===========================================================================
+# pii-invalid-no-pii-annotation: Django model eligibility
+# (mirrors DjangoSearch.requires_annotations() from code_annotations)
+# ===========================================================================
+
+
+def test_plain_python_class_not_checked():
+    """A plain Python class (not a Django Model subclass) with ``.. no_pii:`` and
+    PII fields is NOT flagged — only Django models are in scope."""
+    source = """\
+        class ServiceHelper:
+            '''.. no_pii:'''
+            email = None
+            username = None
+    """
+    messages = _run(source)
+    assert not messages
+
+
+def test_abstract_django_model_not_checked():
+    """An abstract Django model (``abstract = True`` in Meta) is NOT checked.
+
+    ``django_find_annotations`` skips abstract models because they never
+    create database tables; this checker mirrors that behaviour.
+    """
+    source = """\
+        class AbstractBase(Model):
+            '''.. no_pii:'''
+            email = None
+            class Meta:
+                abstract = True
+    """
+    messages = _run(source)
+    assert not messages
+
+
+def test_proxy_django_model_not_checked():
+    """A proxy Django model (``proxy = True`` in Meta) is NOT checked.
+
+    ``django_find_annotations`` skips proxy models because they share
+    the database table of their concrete parent; this checker mirrors
+    that behaviour.
+    """
+    source = """\
+        class ConcreteModel(Model):
+            '''.. no_pii:'''
+            course_id = None
+
+        class ProxyView(ConcreteModel):
+            '''.. no_pii:'''
+            email = None
+            class Meta:
+                proxy = True
+    """
+    messages = _run(source)
+    # ConcreteModel is concrete and has no PII — should not fire.
+    # ProxyView is a proxy — should not fire.
+    assert not messages
+
+
+def test_concrete_model_indirect_inheritance_checked():
+    """A concrete model that inherits from Model indirectly (through a custom
+    base) is still checked — mirroring django_find_annotations coverage."""
+    source = """\
+        class TimeStampedModel(Model):
+            '''.. no_pii:'''
+            course_id = None
+
+        class CourseEnrollment(TimeStampedModel):       #=A
+            '''.. no_pii:'''
+            username = None
+    """
+    messages = _run(source)
+    # CourseEnrollment is concrete and has a PII field — should fire.
+    assert _has(messages, "A", _ANN_ID)
+    assert any("username" in m for m in messages)
+
+
+def test_non_model_class_with_pii_but_no_annotation_ignored():
+    """A plain class with PII fields and NO annotation — not a model, not checked."""
+    source = """\
+        class DataTransferObject:
+            email = None
+            username = None
+    """
+    messages = _run(source)
+    assert not messages

--- a/test/plugins/test_pii_annotation_check.py
+++ b/test/plugins/test_pii_annotation_check.py
@@ -58,7 +58,7 @@ def test_no_pii_multiple_pii_fields_single_message():
     messages = _run(source)
     assert len(messages) == 1
     msg = list(messages)[0]
-    assert "email" in msg and "username" in msg and "phone_number" in msg
+    assert "email" in msg and "username" in msg and "phone_number" not in msg
 
 
 def test_no_pii_with_only_safe_fields_ok():
@@ -108,17 +108,17 @@ def test_pii_annotated_class_not_checked():
 
 
 def test_no_pii_instance_attr_in_method_flagged():
-    """self.phone_number = ... inside __init__ of a .. no_pii: model fires."""
+    """self.username = ... inside __init__ of a .. no_pii: model fires."""
     source = """\
         class UserData(Model):                          #=A
             '''.. no_pii:'''
             def __init__(self, data):
-                self.phone_number = data.phone
+                self.username = data.username
                 self.is_active = data.active
     """
     messages = _run(source)
     assert _has(messages, "A")
-    assert any("self.phone_number" in m for m in messages)
+    assert any("self.username" in m for m in messages)
 
 
 def test_no_pii_annotated_assignment_flagged():

--- a/test/plugins/test_pii_annotation_check.py
+++ b/test/plugins/test_pii_annotation_check.py
@@ -1,49 +1,25 @@
-"""Tests for pii_annotation_check.py (PiiAnnotationChecker).
+"""Tests for PiiAnnotationChecker (pii-invalid-no-pii-annotation / W7633).
 
-Covers the ``pii-invalid-no-pii-annotation`` rule (W7633) emitted by the
-``pii-annotation-checker`` checker.
-
-This rule fires when a concrete (non-abstract, non-proxy) Django model class
-is annotated with ``.. no_pii:`` yet still contains fields or instance
-attributes whose names match the configured PII terms.
-
-Message format produced by run_pylint:
-    "{line_marker}:{symbol}:{message_text}"
-
-e.g.  "A:pii-invalid-no-pii-annotation:Django model 'Profile' is annotated ..."
-
-We test for exact symbol presence using substring matching on the
-marker:symbol prefix.
+Fires when a concrete Django model has ``.. no_pii:`` but still contains PII fields.
 """
 
 from .pylint_test import run_pylint
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_ANN_ID = "pii-invalid-no-pii-annotation"
+_ID = "pii-invalid-no-pii-annotation"
 
 
 def _run(source):
-    """Run pylint checking only pii-invalid-no-pii-annotation."""
-    return run_pylint(source, _ANN_ID)
+    return run_pylint(source, _ID)
 
 
-def _has(messages, marker, symbol):
-    """Return True if messages contains one with the given marker and symbol."""
-    prefix = f"{marker}:{symbol}:"
-    return any(m.startswith(prefix) for m in messages)
+def _has(messages, marker):
+    return any(m.startswith(f"{marker}:{_ID}:") for m in messages)
 
 
-# ===========================================================================
-# pii-invalid-no-pii-annotation: basic detection
-# ===========================================================================
-
+# -- basic detection ----------------------------------------------------------
 
 def test_no_pii_docstring_with_pii_field():
-    """Django model with ``.. no_pii:`` docstring and a PII field fires on the class line."""
+    """.. no_pii: docstring + PII field fires on the class line."""
     source = """\
         class LearnerProfile(Model):                    #=A
             '''
@@ -53,12 +29,12 @@ def test_no_pii_docstring_with_pii_field():
             email = None
     """
     messages = _run(source)
-    assert _has(messages, "A", _ANN_ID)
+    assert _has(messages, "A")
     assert any("email" in m for m in messages)
 
 
 def test_no_pii_comment_above_class():
-    """``# .. no_pii:`` comment above a Django model with PII field fires."""
+    """# .. no_pii: comment above class with PII field fires."""
     source = """\
         # .. no_pii:
         class CourseEnrollment(Model):                  #=A
@@ -66,12 +42,12 @@ def test_no_pii_comment_above_class():
             username = None
     """
     messages = _run(source)
-    assert _has(messages, "A", _ANN_ID)
+    assert _has(messages, "A")
     assert any("username" in m for m in messages)
 
 
 def test_no_pii_multiple_pii_fields_single_message():
-    """Multiple PII fields on a Django model produce exactly one message listing all."""
+    """Multiple PII fields produce exactly one message listing all."""
     source = """\
         class Profile(Model):                           #=A
             '''.. no_pii:'''
@@ -82,50 +58,43 @@ def test_no_pii_multiple_pii_fields_single_message():
     messages = _run(source)
     assert len(messages) == 1
     msg = list(messages)[0]
-    assert "email" in msg
-    assert "username" in msg
-    assert "phone_number" in msg
+    assert "email" in msg and "username" in msg and "phone_number" in msg
 
 
 def test_no_pii_with_only_safe_fields_ok():
-    """Django model with ``.. no_pii:`` and only safe surrogate keys does not fire."""
+    """.. no_pii: with only safe surrogate keys does not fire."""
     source = """\
         class Enrollment(Model):
             '''.. no_pii:'''
             course_id = None
             user_id = None
-            block_id = None
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)
 
 
 def test_no_pii_with_non_pii_fields_ok():
-    """Django model with ``.. no_pii:`` and genuinely non-PII fields is fine."""
+    """.. no_pii: with genuinely non-PII fields does not fire."""
     source = """\
         class CourseGrade(Model):
             '''.. no_pii:'''
             is_passing = True
             percent = 0.0
-            created = None
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)
 
 
 def test_class_without_annotation_not_checked():
-    """A Django model with PII fields but NO annotation is out of scope for this rule."""
+    """Model with PII fields but no annotation is out of scope for this rule."""
     source = """\
         class BadModel(Model):
             email = None
             username = None
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_annotated_class_not_checked():
-    """A Django model with ``.. pii:`` annotation and PII fields is correct — no warning."""
+    """Model with .. pii: annotation and PII fields is correct — no warning."""
     source = """\
         class UserProfile(Model):
             '''
@@ -135,12 +104,11 @@ def test_pii_annotated_class_not_checked():
             '''
             email = None
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)
 
 
 def test_no_pii_instance_attr_in_method_flagged():
-    """``self.phone_number = ...`` inside __init__ of a Django model is caught."""
+    """self.phone_number = ... inside __init__ of a .. no_pii: model fires."""
     source = """\
         class UserData(Model):                          #=A
             '''.. no_pii:'''
@@ -149,69 +117,56 @@ def test_no_pii_instance_attr_in_method_flagged():
                 self.is_active = data.active
     """
     messages = _run(source)
-    assert _has(messages, "A", _ANN_ID)
+    assert _has(messages, "A")
     assert any("self.phone_number" in m for m in messages)
 
 
 def test_no_pii_annotated_assignment_flagged():
-    """``email: str = ""`` (AnnAssign) on a Django model is caught."""
+    """email: str = '' (AnnAssign) on a .. no_pii: model fires."""
     source = """\
         class Profile(Model):                           #=A
             '''.. no_pii:'''
             email: str = ""
     """
-    messages = _run(source)
-    assert _has(messages, "A", _ANN_ID)
+    assert _has(_run(source), "A")
 
 
 def test_no_pii_inline_disable_suppresses():
-    """``# pylint: disable=pii-invalid-no-pii-annotation`` suppresses the rule."""
+    """Inline pylint:disable=pii-invalid-no-pii-annotation suppresses the rule."""
     source = """\
         class Profile(Model):  # pylint: disable=pii-invalid-no-pii-annotation
             '''.. no_pii:'''
             email = None
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)
 
 
 def test_decorator_between_comment_annotation_and_class():
-    """A decorator between the ``# .. no_pii:`` comment and a Django model class is still detected."""
+    """Decorator between # .. no_pii: comment and class is still detected."""
     source = """\
         # .. no_pii:
         @some_decorator
         class Enrollment(Model):                        #=A
             username = None
     """
-    messages = _run(source)
-    assert _has(messages, "A", _ANN_ID)
+    assert _has(_run(source), "A")
 
 
-# ===========================================================================
-# pii-invalid-no-pii-annotation: Django model eligibility
-# (mirrors DjangoSearch.requires_annotations() from code_annotations)
-# ===========================================================================
-
+# -- model eligibility (mirrors django_find_annotations scope) ----------------
 
 def test_plain_python_class_not_checked():
-    """A plain Python class (not a Django Model subclass) with ``.. no_pii:`` and
-    PII fields is NOT flagged — only Django models are in scope."""
+    """Plain Python class (not a Model subclass) is not in scope."""
     source = """\
         class ServiceHelper:
             '''.. no_pii:'''
             email = None
             username = None
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)
 
 
 def test_abstract_django_model_not_checked():
-    """An abstract Django model (``abstract = True`` in Meta) is NOT checked.
-
-    ``django_find_annotations`` skips abstract models because they never
-    create database tables; this checker mirrors that behaviour.
-    """
+    """Abstract Django model (Meta.abstract = True) is not checked."""
     source = """\
         class AbstractBase(Model):
             '''.. no_pii:'''
@@ -219,17 +174,11 @@ def test_abstract_django_model_not_checked():
             class Meta:
                 abstract = True
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)
 
 
 def test_proxy_django_model_not_checked():
-    """A proxy Django model (``proxy = True`` in Meta) is NOT checked.
-
-    ``django_find_annotations`` skips proxy models because they share
-    the database table of their concrete parent; this checker mirrors
-    that behaviour.
-    """
+    """Proxy Django model (Meta.proxy = True) is not checked."""
     source = """\
         class ConcreteModel(Model):
             '''.. no_pii:'''
@@ -241,15 +190,11 @@ def test_proxy_django_model_not_checked():
             class Meta:
                 proxy = True
     """
-    messages = _run(source)
-    # ConcreteModel is concrete and has no PII — should not fire.
-    # ProxyView is a proxy — should not fire.
-    assert not messages
+    assert not _run(source)
 
 
 def test_concrete_model_indirect_inheritance_checked():
-    """A concrete model that inherits from Model indirectly (through a custom
-    base) is still checked — mirroring django_find_annotations coverage."""
+    """Concrete model inheriting Model indirectly is still checked."""
     source = """\
         class TimeStampedModel(Model):
             '''.. no_pii:'''
@@ -260,17 +205,15 @@ def test_concrete_model_indirect_inheritance_checked():
             username = None
     """
     messages = _run(source)
-    # CourseEnrollment is concrete and has a PII field — should fire.
-    assert _has(messages, "A", _ANN_ID)
+    assert _has(messages, "A")
     assert any("username" in m for m in messages)
 
 
 def test_non_model_class_with_pii_but_no_annotation_ignored():
-    """A plain class with PII fields and NO annotation — not a model, not checked."""
+    """Plain class with PII fields and no annotation — not checked."""
     source = """\
         class DataTransferObject:
             email = None
             username = None
     """
-    messages = _run(source)
-    assert not messages
+    assert not _run(source)

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -696,8 +696,6 @@ def test_pii_in_log_new_safe_keys_not_flagged():
             email_sent_on = None
             require_course_email_auth = None
             attr_full_name = None
-            location = None
-            _location = None
             proctoring_escalation_email = None
             email_cadence = None
             def notify(self):
@@ -706,9 +704,27 @@ def test_pii_in_log_new_safe_keys_not_flagged():
                 log.info(self.email_sent_on)
                 log.info(self.require_course_email_auth)
                 log.info(self.attr_full_name)
-                log.info(self.location)
-                log.info(self._location)
                 log.info(self.proctoring_escalation_email)
                 log.info(self.email_cadence)
     """
     assert not _run(source)
+
+
+def test_pii_in_log_location_and__location_flagged():
+    """location and _location are treated as PII terms and should fire."""
+    source = """\
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class ProfileModel(Model):
+            '''.. pii: Stores learner profile PII.'''
+            location = None
+            _location = None
+            def log_profile(self):
+                log.info(self.location)             #=A
+                log.info(self._location)            #=B
+    """
+    messages = _run(source)
+    assert _has(messages, "A")
+    assert _has(messages, "B")

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -1,52 +1,26 @@
-"""Tests for pii_squelch_check.py (PiiMissingSquelchChecker).
+"""Tests for PiiMissingSquelchChecker (pii-missing-squelch / W7630).
 
-Covers the three missing-squelch-guard rules under checker name ``pii-missing-squelch``:
-
-    pii-missing-squelch        (W7630)
-    pii-missing-squelch      (W7631)
-    pii-missing-squelch  (W7632)
-
-Scope: checks only fire inside annotation-eligible Django model methods.
-  - Models with ``.. no_pii:``       → entirely skipped (safe, no squelch check).
-  - Models with ``.. pii:`` or none  → checked: methods must use SQUELCH guard.
-  - Standalone functions / module-level code → entirely out of scope.
-
-Every test source defines a top-level ``class Model: pass`` stub so the
-checker's raw-AST BFS can recognise subclasses without Django being installed.
-
-Message format produced by run_pylint:
-    "{line_marker}:{symbol}:{message_text}"
-e.g.  "A:pii-missing-squelch:Log call exposes PII term 'email' without ..."
+Checks fire only inside non-abstract, non-proxy Django model methods.
+Models annotated ``.. no_pii:`` are skipped; all others are enforced.
 """
 
 from .pylint_test import run_pylint
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _run(source, *msg_ids):
-    """Run pylint and return the set of messages for the given msg_ids."""
-    return run_pylint(source, ",".join(msg_ids))
+_ID = "pii-missing-squelch"
 
 
-def _has(messages, marker, symbol):
-    """Return True if messages contains one with the given marker and symbol."""
-    prefix = f"{marker}:{symbol}:"
-    return any(m.startswith(prefix) for m in messages)
+def _run(source):
+    return run_pylint(source, _ID)
 
 
-ALL_SQUELCH_IDS = ("pii-missing-squelch", "pii-missing-squelch", "pii-missing-squelch")
+def _has(messages, marker):
+    return any(m.startswith(f"{marker}:{_ID}:") for m in messages)
 
 
-# ===========================================================================
-# pii-missing-squelch — inside a .. pii: annotated Django model method
-# ===========================================================================
-
+# -- pii-in-log ---------------------------------------------------------------
 
 def test_pii_in_log_bare_name():
-    """Bare PII variable logged inside a pii model method without guard fires."""
+    """Unguarded PII variable in log.info fires."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -57,12 +31,11 @@ class UserModel(Model):
     def notify(self):
         log.info("user: %s", email)          #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_log_fstring():
-    """PII inside an f-string logged in a pii model method fires."""
+    """PII inside an f-string in a log call fires."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -73,12 +46,11 @@ class UserModel(Model):
     def notify(self):
         log.warning(f"email: {email}")       #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_log_attribute_access():
-    """Attribute access self.email logged in a pii model method fires."""
+    """self.email passed to log fires."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -90,12 +62,11 @@ class UserModel(Model):
     def notify(self):
         log.error("failed: %s", self.email)  #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_log_nested_in_dict():
-    """PII inside a dict value logged in a pii model method fires."""
+    """PII inside a dict value passed to log fires."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -106,16 +77,11 @@ class UserModel(Model):
     def notify(self):
         log.info("%s", {"email": email})     #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_log_string_literal_not_flagged():
-    """A literal log message mentioning a PII word does NOT fire inside a pii model.
-
-    Only actual PII variable/attribute references are flagged — string
-    literals that name a PII field are message text, not PII values.
-    """
+    """String literals containing PII words are not flagged (not actual PII values)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -126,14 +92,12 @@ class UserModel(Model):
     def notify(self):
         log.info("user email: unknown")
         log.info("Email field is required")
-        log.info("Invalid email format")
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_bare_flag():
-    """PII log inside ``if not SQUELCH_PII_IN_LOGS:`` in a pii model is allowed."""
+    """PII log inside ``if not SQUELCH_PII_IN_LOGS:`` is safe."""
     source = """\
 import logging
 SQUELCH_PII_IN_LOGS = True
@@ -146,12 +110,11 @@ class UserModel(Model):
         if not SQUELCH_PII_IN_LOGS:
             log.info("email=%s", email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_flag_positive():
-    """PII log in else-branch of ``if SQUELCH_PII_IN_LOGS:`` in a pii model is allowed."""
+    """PII log in else-branch of ``if SQUELCH_PII_IN_LOGS:`` is safe."""
     source = """\
 import logging
 SQUELCH_PII_IN_LOGS = True
@@ -166,12 +129,11 @@ class UserModel(Model):
         else:
             log.info("email=%s", email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_features_subscript():
-    """settings.FEATURES['SQUELCH_PII_IN_LOGS'] guard inside a pii model is recognised."""
+    """settings.FEATURES['SQUELCH_PII_IN_LOGS'] guard is recognised."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -183,12 +145,11 @@ class UserModel(Model):
         if not settings.FEATURES['SQUELCH_PII_IN_LOGS']:
             log.info("email=%s", email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_features_get():
-    """settings.FEATURES.get('SQUELCH_PII_IN_LOGS') guard inside a pii model is recognised."""
+    """settings.FEATURES.get('SQUELCH_PII_IN_LOGS') guard is recognised."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -200,12 +161,11 @@ class UserModel(Model):
         if not settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):
             log.info("username=%s", username)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_attribute():
-    """settings.SQUELCH_PII_IN_LOGS guard inside a pii model is recognised."""
+    """settings.SQUELCH_PII_IN_LOGS guard is recognised."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -217,12 +177,11 @@ class UserModel(Model):
         if not settings.SQUELCH_PII_IN_LOGS:
             log.info("phone=%s", phone_number)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_safe_function_wrapping():
-    """PII wrapped in redact() inside a pii model is not flagged."""
+    """PII wrapped in redact() is not flagged."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -233,12 +192,11 @@ class UserModel(Model):
     def notify(self):
         log.info("value=%s", redact(email))
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_safe_key_not_flagged():
-    """user_id is a safe surrogate key — not flagged even inside a pii model."""
+    """Surrogate key user_id is not flagged."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -249,12 +207,11 @@ class EnrollmentModel(Model):
     def log_action(self):
         log.info("enrolled user_id=%s", user_id)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_non_pii_name_not_flagged():
-    """Completely unrelated variable names inside a pii model do not fire."""
+    """Non-PII variable names are not flagged."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -265,12 +222,11 @@ class CourseModel(Model):
     def log_action(self):
         log.info("enrolled course: %s", course_data)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_log_multiple_levels():
-    """All standard log levels inside a pii model trigger the rule."""
+    """All standard log levels fire inside a pii model."""
     for method in ("debug", "info", "warning", "error", "critical", "exception"):
         source = (
             "import logging\n"
@@ -282,14 +238,11 @@ def test_pii_in_log_multiple_levels():
             "    def notify(self):\n"
             f"        log.{method}('msg: %s', email)     #=A\n"
         )
-        messages = _run(source, "pii-missing-squelch")
-        assert _has(messages, "A", "pii-missing-squelch"), (
-            f"Expected pii-missing-squelch for log.{method} inside a pii model"
-        )
+        assert _has(_run(source), "A"), f"Expected pii-missing-squelch for log.{method}"
 
 
 def test_pii_in_log_inline_disable_suppresses():
-    """Inline ``# pylint: disable=pii-missing-squelch`` suppresses the warning inside a model."""
+    """Inline pylint:disable=pii-missing-squelch suppresses the warning."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -300,17 +253,13 @@ class UserModel(Model):
     def notify(self):
         log.info("email=%s", email)  # pylint: disable=pii-missing-squelch
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
-# ===========================================================================
-# OEP-0030 new terms — job title, social media, website
-# ===========================================================================
-
+# -- OEP-0030 extended terms --------------------------------------------------
 
 def test_pii_in_log_job_title_fires():
-    """job_title inside a pii model fires (OEP-0030: 'Job title' is PII)."""
+    """job_title fires (OEP-0030 PII term)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -321,12 +270,11 @@ class ProfileModel(Model):
     def log_profile(self):
         log.info("user info: %s", job_title)     #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_log_title_attribute_fires():
-    """self.title inside a pii model fires (OEP-0030: 'Job title' is PII)."""
+    """self.title fires (OEP-0030: Job title is PII)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -338,12 +286,11 @@ class ProfileModel(Model):
     def log_profile(self):
         log.info("user: %s", self.title)         #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_log_social_fires():
-    """social_link inside a pii model fires (OEP-0030: social media is PII)."""
+    """social_link fires (OEP-0030 PII term)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -354,12 +301,11 @@ class ProfileModel(Model):
     def log_profile(self):
         log.info("link: %s", social_link)        #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_log_website_fires():
-    """user_website inside a pii model fires (OEP-0030: website is PII)."""
+    """user_website fires (OEP-0030 PII term)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -370,17 +316,11 @@ class ProfileModel(Model):
     def log_profile(self):
         log.info("site: %s", user_website)       #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
-
-
-# ===========================================================================
-# Non-OEP-0030 terms: token and secret never fire
-# ===========================================================================
+    assert _has(_run(source), "A")
 
 
 def test_token_not_flagged_not_in_oep30():
-    """'token' is not an OEP-0030 PII field — does not fire inside a model."""
+    """'token' is not an OEP-0030 field — never fires."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -391,12 +331,11 @@ class SessionModel(Model):
     def log_action(self):
         log.info("auth: %s", access_token)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_secret_not_flagged_not_in_oep30():
-    """'secret' is not an OEP-0030 PII field — does not fire inside a model."""
+    """'secret' is not an OEP-0030 field — never fires."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -407,17 +346,13 @@ class ApiModel(Model):
     def log_action(self):
         log.info("key: %s", api_secret)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
-# ===========================================================================
-# pii-missing-squelch — inside a .. pii: annotated Django model method
-# ===========================================================================
-
+# -- pii-in-print -------------------------------------------------------------
 
 def test_pii_in_print_bare():
-    """print(pii_var) inside a pii model method fires."""
+    """print(pii_var) inside a pii model fires."""
     source = """\
 class Model:
     pass
@@ -426,12 +361,11 @@ class UserModel(Model):
     def display(self):
         print(username)                          #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_print_fstring():
-    """print() with PII in an f-string inside a pii model fires."""
+    """print() with PII in an f-string fires."""
     source = """\
 class Model:
     pass
@@ -440,12 +374,11 @@ class UserModel(Model):
     def display(self):
         print(f"user: {username}")               #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_print_guarded():
-    """print() with PII inside SQUELCH guard in a pii model does not fire."""
+    """print() with PII inside SQUELCH guard does not fire."""
     source = """\
 SQUELCH_PII_IN_LOGS = True
 class Model:
@@ -456,12 +389,11 @@ class UserModel(Model):
         if not SQUELCH_PII_IN_LOGS:
             print(username)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_stdout_write():
-    """sys.stdout.write() with PII inside a pii model fires."""
+    """sys.stdout.write() with PII fires."""
     source = """\
 import sys
 class Model:
@@ -471,12 +403,11 @@ class ReportModel(Model):
     def export(self):
         sys.stdout.write(email)                  #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_stderr_write():
-    """sys.stderr.write() with PII inside a pii model fires."""
+    """sys.stderr.write() with PII fires."""
     source = """\
 import sys
 class Model:
@@ -486,12 +417,11 @@ class ReportModel(Model):
     def export(self):
         sys.stderr.write(username)               #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_print_safe_key_not_flagged():
-    """Printing user_id (safe surrogate key) inside a pii model does not fire."""
+    """Printing user_id (safe surrogate key) does not fire."""
     source = """\
 class Model:
     pass
@@ -500,14 +430,10 @@ class EnrollmentModel(Model):
     def display(self):
         print(user_id)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
-# ===========================================================================
-# pii-missing-squelch — inside a .. pii: annotated Django model method
-# ===========================================================================
-
+# -- pii-in-exception ---------------------------------------------------------
 
 def test_pii_in_exception_bare():
     """raise ValueError(pii_var) inside a pii model fires."""
@@ -519,12 +445,11 @@ class PaymentModel(Model):
     def validate(self):
         raise ValueError(email)                  #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_exception_fstring():
-    """raise ValueError(f\"...{pii}...\") inside a pii model fires."""
+    """raise ValueError(f-string with PII) fires."""
     source = """\
 class Model:
     pass
@@ -533,12 +458,11 @@ class PaymentModel(Model):
     def validate(self):
         raise ValueError(f"bad username: {username}")   #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_pii_in_exception_guarded():
-    """Exception with PII inside SQUELCH guard in a pii model does not fire."""
+    """Exception with PII inside SQUELCH guard does not fire."""
     source = """\
 SQUELCH_PII_IN_LOGS = True
 class Model:
@@ -549,12 +473,11 @@ class PaymentModel(Model):
         if not SQUELCH_PII_IN_LOGS:
             raise ValueError(email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_exception_safe_function():
-    """Exception with PII wrapped in redact() inside a pii model does not fire."""
+    """raise ValueError(redact(pii)) does not fire."""
     source = """\
 class Model:
     pass
@@ -563,12 +486,11 @@ class PaymentModel(Model):
     def validate(self):
         raise ValueError(redact(email))
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_pii_in_exception_safe_key():
-    """Exception with safe surrogate key (user_id) inside a pii model does not fire."""
+    """raise ValueError(user_id) does not fire (safe surrogate key)."""
     source = """\
 class Model:
     pass
@@ -577,12 +499,11 @@ class PaymentModel(Model):
     def validate(self):
         raise ValueError(user_id)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_non_sink_call_not_flagged():
-    """An arbitrary function call with PII inside a pii model is not flagged."""
+    """Arbitrary function calls with PII are not flagged."""
     source = """\
 class Model:
     pass
@@ -591,60 +512,42 @@ class UserModel(Model):
     def process(self):
         some_function(email)
 """
-    messages = _run(source, *ALL_SQUELCH_IDS)
-    assert not messages
+    assert not _run(source)
 
 
-# ===========================================================================
-# Scope: standalone / module-level code is OUT OF SCOPE for squelch checks
-# ===========================================================================
-
+# -- Scope: out-of-model code is not checked ----------------------------------
 
 def test_standalone_function_not_checked():
-    """Logs inside a standalone function (not inside any model) are NOT checked.
-
-    The squelch-guard check only applies to methods inside Django model
-    classes.  Code outside a model is out of OEP-0030 annotation scope.
-    """
+    """Logs inside a standalone function (not a model method) are not checked."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
 def standalone_helper(email):
     log.info(email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_module_level_print_not_checked():
-    """A print() at module level is NOT checked — only model methods are in scope."""
+    """Module-level print() is not checked."""
     source = """\
 print(username)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_module_level_raise_not_checked():
-    """A raise at module level is NOT checked — only model methods are in scope."""
+    """Module-level raise is not checked."""
     source = """\
 raise ValueError(email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
-# ===========================================================================
-# Scope: .. no_pii: models are completely skipped for squelch checks
-# ===========================================================================
-
+# -- Scope: .. no_pii: models are skipped -------------------------------------
 
 def test_squelch_exempt_in_no_pii_model():
-    """Logs inside a model annotated with .. no_pii: are entirely skipped.
-
-    The .. no_pii: annotation declares the model safe — no squelch guard
-    is required even if PII-named attributes are passed to a log sink.
-    """
+    """Logs inside a .. no_pii: model are entirely skipped."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -656,12 +559,11 @@ class SafeModel(Model):
     def log_something(self):
         log.info(self.email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)
 
 
 def test_squelch_enforced_in_pii_model():
-    """Unguarded PII log inside a .. pii: annotated model fires."""
+    """Unguarded PII log inside a .. pii: model fires."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -673,16 +575,11 @@ class UnsafeModel(Model):
     def log_something(self):
         log.info(self.email)                     #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_squelch_enforced_in_unannotated_model():
-    """Unguarded PII log inside a model with NO annotation also fires.
-
-    A model without any PII annotation has not been declared safe and has
-    not been declared PII-aware; the checker conservatively flags it.
-    """
+    """Unguarded PII log inside a model with no annotation fires (conservative)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -693,12 +590,11 @@ class UnannotatedModel(Model):
     def log_something(self):
         log.info(self.email)                     #=A
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert _has(messages, "A", "pii-missing-squelch")
+    assert _has(_run(source), "A")
 
 
 def test_squelch_enforced_guarded_in_pii_model():
-    """Properly guarded PII log inside a .. pii: model does NOT fire."""
+    """Properly guarded PII log inside a .. pii: model does not fire."""
     source = """\
 import logging
 SQUELCH_PII_IN_LOGS = True
@@ -712,5 +608,4 @@ class UnsafeModel(Model):
         if not SQUELCH_PII_IN_LOGS:
             log.info(self.email)
 """
-    messages = _run(source, "pii-missing-squelch")
-    assert not messages
+    assert not _run(source)

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -1,0 +1,718 @@
+"""Tests for pii_squelch_check.py (PiiMissingSquelchChecker).
+
+Covers the three missing-squelch-guard rules under checker name ``pii-missing-squelch``:
+
+    pii-missing-squelch        (W7630)
+    pii-missing-squelch      (W7631)
+    pii-missing-squelch  (W7632)
+
+Scope: checks only fire inside annotation-eligible Django model methods.
+  - Models with ``.. no_pii:``       → entirely skipped (safe, no squelch check).
+  - Models with ``.. pii:`` or none  → checked: methods must use SQUELCH guard.
+  - Standalone functions / module-level code → entirely out of scope.
+
+Every test source defines a top-level ``class Model: pass`` stub so the
+checker's raw-AST BFS can recognise subclasses without Django being installed.
+
+Message format produced by run_pylint:
+    "{line_marker}:{symbol}:{message_text}"
+e.g.  "A:pii-missing-squelch:Log call exposes PII term 'email' without ..."
+"""
+
+import pytest
+
+from .pylint_test import run_pylint
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(source, *msg_ids):
+    """Run pylint and return the set of messages for the given msg_ids."""
+    return run_pylint(source, ",".join(msg_ids))
+
+
+def _has(messages, marker, symbol):
+    """Return True if messages contains one with the given marker and symbol."""
+    prefix = f"{marker}:{symbol}:"
+    return any(m.startswith(prefix) for m in messages)
+
+
+ALL_SQUELCH_IDS = ("pii-missing-squelch", "pii-missing-squelch", "pii-missing-squelch")
+
+
+# ===========================================================================
+# pii-missing-squelch — inside a .. pii: annotated Django model method
+# ===========================================================================
+
+
+def test_pii_in_log_bare_name():
+    """Bare PII variable logged inside a pii model method without guard fires."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("user: %s", email)          #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_log_fstring():
+    """PII inside an f-string logged in a pii model method fires."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.warning(f"email: {email}")       #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_log_attribute_access():
+    """Attribute access self.email logged in a pii model method fires."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    email = None
+    def notify(self):
+        log.error("failed: %s", self.email)  #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_log_nested_in_dict():
+    """PII inside a dict value logged in a pii model method fires."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("%s", {"email": email})     #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_log_string_literal_not_flagged():
+    """A literal log message mentioning a PII word does NOT fire inside a pii model.
+
+    Only actual PII variable/attribute references are flagged — string
+    literals that name a PII field are message text, not PII values.
+    """
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("user email: unknown")
+        log.info("Email field is required")
+        log.info("Invalid email format")
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_guarded_by_bare_flag():
+    """PII log inside ``if not SQUELCH_PII_IN_LOGS:`` in a pii model is allowed."""
+    source = """\
+import logging
+SQUELCH_PII_IN_LOGS = True
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not SQUELCH_PII_IN_LOGS:
+            log.info("email=%s", email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_guarded_by_flag_positive():
+    """PII log in else-branch of ``if SQUELCH_PII_IN_LOGS:`` in a pii model is allowed."""
+    source = """\
+import logging
+SQUELCH_PII_IN_LOGS = True
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if SQUELCH_PII_IN_LOGS:
+            log.info("user_id=%s", user_id)
+        else:
+            log.info("email=%s", email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_guarded_by_settings_features_subscript():
+    """settings.FEATURES['SQUELCH_PII_IN_LOGS'] guard inside a pii model is recognised."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+            log.info("email=%s", email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_guarded_by_settings_features_get():
+    """settings.FEATURES.get('SQUELCH_PII_IN_LOGS') guard inside a pii model is recognised."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):
+            log.info("username=%s", username)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_guarded_by_settings_attribute():
+    """settings.SQUELCH_PII_IN_LOGS guard inside a pii model is recognised."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not settings.SQUELCH_PII_IN_LOGS:
+            log.info("phone=%s", phone_number)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_safe_function_wrapping():
+    """PII wrapped in redact() inside a pii model is not flagged."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("value=%s", redact(email))
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_safe_key_not_flagged():
+    """user_id is a safe surrogate key — not flagged even inside a pii model."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class EnrollmentModel(Model):
+    '''.. pii: Stores enrollment data.'''
+    def log_action(self):
+        log.info("enrolled user_id=%s", user_id)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_non_pii_name_not_flagged():
+    """Completely unrelated variable names inside a pii model do not fire."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class CourseModel(Model):
+    '''.. pii: Stores course data.'''
+    def log_action(self):
+        log.info("enrolled course: %s", course_data)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_log_multiple_levels():
+    """All standard log levels inside a pii model trigger the rule."""
+    for method in ("debug", "info", "warning", "error", "critical", "exception"):
+        source = (
+            "import logging\n"
+            "log = logging.getLogger(__name__)\n"
+            "class Model:\n"
+            "    pass\n"
+            "class UserModel(Model):\n"
+            "    '''.. pii: Stores user PII.'''\n"
+            "    def notify(self):\n"
+            f"        log.{method}('msg: %s', email)     #=A\n"
+        )
+        messages = _run(source, "pii-missing-squelch")
+        assert _has(messages, "A", "pii-missing-squelch"), (
+            f"Expected pii-missing-squelch for log.{method} inside a pii model"
+        )
+
+
+def test_pii_in_log_inline_disable_suppresses():
+    """Inline ``# pylint: disable=pii-missing-squelch`` suppresses the warning inside a model."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("email=%s", email)  # pylint: disable=pii-missing-squelch
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+# ===========================================================================
+# OEP-0030 new terms — job title, social media, website
+# ===========================================================================
+
+
+def test_pii_in_log_job_title_fires():
+    """job_title inside a pii model fires (OEP-0030: 'Job title' is PII)."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    def log_profile(self):
+        log.info("user info: %s", job_title)     #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_log_title_attribute_fires():
+    """self.title inside a pii model fires (OEP-0030: 'Job title' is PII)."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    title = None
+    def log_profile(self):
+        log.info("user: %s", self.title)         #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_log_social_fires():
+    """social_link inside a pii model fires (OEP-0030: social media is PII)."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    def log_profile(self):
+        log.info("link: %s", social_link)        #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_log_website_fires():
+    """user_website inside a pii model fires (OEP-0030: website is PII)."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    def log_profile(self):
+        log.info("site: %s", user_website)       #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+# ===========================================================================
+# Non-OEP-0030 terms: token and secret never fire
+# ===========================================================================
+
+
+def test_token_not_flagged_not_in_oep30():
+    """'token' is not an OEP-0030 PII field — does not fire inside a model."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SessionModel(Model):
+    '''.. pii: Stores session data.'''
+    def log_action(self):
+        log.info("auth: %s", access_token)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_secret_not_flagged_not_in_oep30():
+    """'secret' is not an OEP-0030 PII field — does not fire inside a model."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ApiModel(Model):
+    '''.. pii: Stores API data.'''
+    def log_action(self):
+        log.info("key: %s", api_secret)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+# ===========================================================================
+# pii-missing-squelch — inside a .. pii: annotated Django model method
+# ===========================================================================
+
+
+def test_pii_in_print_bare():
+    """print(pii_var) inside a pii model method fires."""
+    source = """\
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def display(self):
+        print(username)                          #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_print_fstring():
+    """print() with PII in an f-string inside a pii model fires."""
+    source = """\
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def display(self):
+        print(f"user: {username}")               #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_print_guarded():
+    """print() with PII inside SQUELCH guard in a pii model does not fire."""
+    source = """\
+SQUELCH_PII_IN_LOGS = True
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def display(self):
+        if not SQUELCH_PII_IN_LOGS:
+            print(username)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_stdout_write():
+    """sys.stdout.write() with PII inside a pii model fires."""
+    source = """\
+import sys
+class Model:
+    pass
+class ReportModel(Model):
+    '''.. pii: Stores report PII.'''
+    def export(self):
+        sys.stdout.write(email)                  #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_stderr_write():
+    """sys.stderr.write() with PII inside a pii model fires."""
+    source = """\
+import sys
+class Model:
+    pass
+class ReportModel(Model):
+    '''.. pii: Stores report PII.'''
+    def export(self):
+        sys.stderr.write(username)               #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_print_safe_key_not_flagged():
+    """Printing user_id (safe surrogate key) inside a pii model does not fire."""
+    source = """\
+class Model:
+    pass
+class EnrollmentModel(Model):
+    '''.. pii: Stores enrollment data.'''
+    def display(self):
+        print(user_id)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+# ===========================================================================
+# pii-missing-squelch — inside a .. pii: annotated Django model method
+# ===========================================================================
+
+
+def test_pii_in_exception_bare():
+    """raise ValueError(pii_var) inside a pii model fires."""
+    source = """\
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        raise ValueError(email)                  #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_exception_fstring():
+    """raise ValueError(f\"...{pii}...\") inside a pii model fires."""
+    source = """\
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        raise ValueError(f"bad username: {username}")   #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_pii_in_exception_guarded():
+    """Exception with PII inside SQUELCH guard in a pii model does not fire."""
+    source = """\
+SQUELCH_PII_IN_LOGS = True
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        if not SQUELCH_PII_IN_LOGS:
+            raise ValueError(email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_exception_safe_function():
+    """Exception with PII wrapped in redact() inside a pii model does not fire."""
+    source = """\
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        raise ValueError(redact(email))
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_pii_in_exception_safe_key():
+    """Exception with safe surrogate key (user_id) inside a pii model does not fire."""
+    source = """\
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        raise ValueError(user_id)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_non_sink_call_not_flagged():
+    """An arbitrary function call with PII inside a pii model is not flagged."""
+    source = """\
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def process(self):
+        some_function(email)
+"""
+    messages = _run(source, *ALL_SQUELCH_IDS)
+    assert not messages
+
+
+# ===========================================================================
+# Scope: standalone / module-level code is OUT OF SCOPE for squelch checks
+# ===========================================================================
+
+
+def test_standalone_function_not_checked():
+    """Logs inside a standalone function (not inside any model) are NOT checked.
+
+    The squelch-guard check only applies to methods inside Django model
+    classes.  Code outside a model is out of OEP-0030 annotation scope.
+    """
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+def standalone_helper(email):
+    log.info(email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_module_level_print_not_checked():
+    """A print() at module level is NOT checked — only model methods are in scope."""
+    source = """\
+print(username)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_module_level_raise_not_checked():
+    """A raise at module level is NOT checked — only model methods are in scope."""
+    source = """\
+raise ValueError(email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+# ===========================================================================
+# Scope: .. no_pii: models are completely skipped for squelch checks
+# ===========================================================================
+
+
+def test_squelch_exempt_in_no_pii_model():
+    """Logs inside a model annotated with .. no_pii: are entirely skipped.
+
+    The .. no_pii: annotation declares the model safe — no squelch guard
+    is required even if PII-named attributes are passed to a log sink.
+    """
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SafeModel(Model):
+    '''.. no_pii: This model holds no PII.'''
+    email = None
+    def log_something(self):
+        log.info(self.email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages
+
+
+def test_squelch_enforced_in_pii_model():
+    """Unguarded PII log inside a .. pii: annotated model fires."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UnsafeModel(Model):
+    '''.. pii: Stores user PII.'''
+    email = None
+    def log_something(self):
+        log.info(self.email)                     #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_squelch_enforced_in_unannotated_model():
+    """Unguarded PII log inside a model with NO annotation also fires.
+
+    A model without any PII annotation has not been declared safe and has
+    not been declared PII-aware; the checker conservatively flags it.
+    """
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UnannotatedModel(Model):
+    email = None
+    def log_something(self):
+        log.info(self.email)                     #=A
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert _has(messages, "A", "pii-missing-squelch")
+
+
+def test_squelch_enforced_guarded_in_pii_model():
+    """Properly guarded PII log inside a .. pii: model does NOT fire."""
+    source = """\
+import logging
+SQUELCH_PII_IN_LOGS = True
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UnsafeModel(Model):
+    '''.. pii: Stores user PII.'''
+    email = None
+    def log_something(self):
+        if not SQUELCH_PII_IN_LOGS:
+            log.info(self.email)
+"""
+    messages = _run(source, "pii-missing-squelch")
+    assert not messages

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -1,7 +1,6 @@
 """Tests for PiiMissingSquelchChecker (pii-missing-squelch / W7630).
 
-Checks fire only inside non-abstract, non-proxy Django model methods.
-Models annotated ``.. no_pii:`` are skipped; all others are enforced.
+Checks fire for unguarded PII sinks across all linted Python code.
 """
 
 from .pylint_test import run_pylint
@@ -22,223 +21,223 @@ def _has(messages, marker):
 def test_pii_in_log_bare_name():
     """Unguarded PII variable in log.info fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                log.info("user: %s", email)          #=A
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("user: %s", email)          #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_fstring():
     """PII inside an f-string in a log call fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                log.warning(f"email: {email}")       #=A
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.warning(f"email: {email}")       #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_attribute_access():
     """self.email passed to log fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            email = None
-            def notify(self):
-                log.error("failed: %s", self.email)  #=A
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    email = None
+    def notify(self):
+        log.error("failed: %s", self.email)  #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_nested_in_dict():
     """PII inside a dict value passed to log fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                log.info("%s", {"email": email})     #=A
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("%s", {"email": email})     #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_string_literal_not_flagged():
     """String literals containing PII words are not flagged (not actual PII values)."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                log.info("user email: unknown")
-                log.info("Email field is required")
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("user email: unknown")
+        log.info("Email field is required")
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_bare_flag():
     """PII log inside ``if not SQUELCH_PII_IN_LOGS:`` is safe."""
     source = """\
-        import logging
-        SQUELCH_PII_IN_LOGS = True
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                if not SQUELCH_PII_IN_LOGS:
-                    log.info("email=%s", email)
-    """
+import logging
+SQUELCH_PII_IN_LOGS = True
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not SQUELCH_PII_IN_LOGS:
+            log.info("email=%s", email)
+"""
     assert not _run(source)
 
 
-def test_pii_in_log_in_else_branch_of_squelch_guard():
-    """PII log in the else-branch of ``if SQUELCH_PII_IN_LOGS:`` is safe."""
+def test_pii_in_log_guarded_by_flag_positive():
+    """PII log in else-branch of ``if SQUELCH_PII_IN_LOGS:`` is safe."""
     source = """\
-        import logging
-        SQUELCH_PII_IN_LOGS = True
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                if SQUELCH_PII_IN_LOGS:
-                    log.info("user_id=%s", user_id)
-                else:
-                    log.info("email=%s", email)
-    """
+import logging
+SQUELCH_PII_IN_LOGS = True
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if SQUELCH_PII_IN_LOGS:
+            log.info("user_id=%s", user_id)
+        else:
+            log.info("email=%s", email)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_features_subscript():
     """settings.FEATURES['SQUELCH_PII_IN_LOGS'] guard is recognised."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                if not settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-                    log.info("email=%s", email)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+            log.info("email=%s", email)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_features_get():
     """settings.FEATURES.get('SQUELCH_PII_IN_LOGS') guard is recognised."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                if not settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):
-                    log.info("username=%s", username)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):
+            log.info("username=%s", username)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_attribute():
     """settings.SQUELCH_PII_IN_LOGS guard is recognised."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                if not settings.SQUELCH_PII_IN_LOGS:
-                    log.info("phone=%s", phone_number)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not settings.SQUELCH_PII_IN_LOGS:
+            log.info("phone=%s", phone_number)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_getattr_settings():
     """getattr(settings, 'SQUELCH_PII_IN_LOGS', False) guard is recognised."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
-                    log.info("email=%s", email)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
+            log.info("email=%s", email)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_not_getattr_settings():
     """``if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):`` guard is recognised."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
-                    log.info("username=%s", username)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
+            log.info("username=%s", username)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_safe_key_not_flagged():
     """Surrogate key user_id is not flagged."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class EnrollmentModel(Model):
-            '''.. pii: Stores enrollment data.'''
-            def log_action(self):
-                log.info("enrolled user_id=%s", user_id)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class EnrollmentModel(Model):
+    '''.. pii: Stores enrollment data.'''
+    def log_action(self):
+        log.info("enrolled user_id=%s", user_id)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_non_pii_name_not_flagged():
     """Non-PII variable names are not flagged."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class CourseModel(Model):
-            '''.. pii: Stores course data.'''
-            def log_action(self):
-                log.info("enrolled course: %s", course_data)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class CourseModel(Model):
+    '''.. pii: Stores course data.'''
+    def log_action(self):
+        log.info("enrolled course: %s", course_data)
+"""
     assert not _run(source)
 
 
@@ -261,80 +260,80 @@ def test_pii_in_log_multiple_levels():
 def test_pii_in_log_inline_disable_suppresses():
     """Inline pylint:disable=pii-missing-squelch suppresses the warning."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def notify(self):
-                log.info("email=%s", email)  # pylint: disable=pii-missing-squelch
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        log.info("email=%s", email)  # pylint: disable=pii-missing-squelch
+"""
     assert not _run(source)
 
 
 # -- OEP-0030 extended terms --------------------------------------------------
 
-def test_pii_in_log_job_title_fires():
-    """job_title fires (OEP-0030 PII term)."""
+def test_pii_in_log_job_title_not_flagged_in_mvp_defaults():
+    """job_title does not fire in conservative MVP defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class ProfileModel(Model):
-            '''.. pii: Stores learner profile PII.'''
-            def log_profile(self):
-                log.info("user info: %s", job_title)     #=A
-    """
-    assert _has(_run(source), "A")
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    def log_profile(self):
+        log.info("user info: %s", job_title)     #=A
+"""
+    assert not _run(source)
 
 
-def test_pii_in_log_social_link_fires():
-    """social_link fires (OEP-0030 PII term — explicit form)."""
+def test_pii_in_log_social_link_not_flagged_in_mvp_defaults():
+    """social_link does not fire in conservative MVP defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class ProfileModel(Model):
-            '''.. pii: Stores learner profile PII.'''
-            def log_profile(self):
-                log.info("link: %s", social_link)        #=A
-    """
-    assert _has(_run(source), "A")
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    def log_profile(self):
+        log.info("link: %s", social_link)        #=A
+"""
+    assert not _run(source)
 
 
-def test_pii_in_log_profile_image_fires():
-    """profile_image fires (OEP-0030 PII term — explicit form)."""
+def test_pii_in_log_profile_image_not_flagged_in_mvp_defaults():
+    """profile_image does not fire in conservative MVP defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class ProfileModel(Model):
-            '''.. pii: Stores learner profile PII.'''
-            profile_image = None
-            def log_profile(self):
-                log.info("img: %s", self.profile_image)  #=A
-    """
-    assert _has(_run(source), "A")
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    profile_image = None
+    def log_profile(self):
+        log.info("img: %s", self.profile_image)  #=A
+"""
+    assert not _run(source)
 
 
-def test_pii_in_log_ip_address_fires():
-    """ip_address fires (OEP-0030 PII term — explicit form)."""
+def test_pii_in_log_ip_address_not_flagged_in_mvp_defaults():
+    """ip_address does not fire in conservative MVP defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class SessionModel(Model):
-            '''.. pii: Stores session PII.'''
-            ip_address = None
-            def log_session(self):
-                log.info("ip: %s", self.ip_address)      #=A
-    """
-    assert _has(_run(source), "A")
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SessionModel(Model):
+    '''.. pii: Stores session PII.'''
+    ip_address = None
+    def log_session(self):
+        log.info("ip: %s", self.ip_address)      #=A
+"""
+    assert not _run(source)
 
 
 # -- Curated exclusions: formerly-generic terms no longer fire by default -----
@@ -342,94 +341,94 @@ def test_pii_in_log_ip_address_fires():
 def test_bare_name_not_flagged():
     """self.name inside a PII model does NOT fire — 'name' removed from defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            name = None
-            def log_action(self):
-                log.info("item: %s", self.name)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    name = None
+    def log_action(self):
+        log.info("item: %s", self.name)
+"""
     assert not _run(source)
 
 
 def test_bare_title_not_flagged():
     """self.title inside a PII model does NOT fire — bare 'title' removed from defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class ProfileModel(Model):
-            '''.. pii: Stores learner profile PII.'''
-            title = None
-            def log_profile(self):
-                log.info("user: %s", self.title)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    title = None
+    def log_profile(self):
+        log.info("user: %s", self.title)
+"""
     assert not _run(source)
 
 
 def test_bare_image_not_flagged():
     """self.image inside a PII model does NOT fire — generic 'image' removed from defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class CourseModel(Model):
-            '''.. pii: Stores course data.'''
-            image = None
-            def log_course(self):
-                log.info("img: %s", self.image)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class CourseModel(Model):
+    '''.. pii: Stores course data.'''
+    image = None
+    def log_course(self):
+        log.info("img: %s", self.image)
+"""
     assert not _run(source)
 
 
 def test_bare_ip_not_flagged():
     """self.ip inside a PII model does NOT fire — bare 'ip' removed from defaults."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class SessionModel(Model):
-            '''.. pii: Stores session PII.'''
-            ip = None
-            def log_session(self):
-                log.info("ip: %s", self.ip)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SessionModel(Model):
+    '''.. pii: Stores session PII.'''
+    ip = None
+    def log_session(self):
+        log.info("ip: %s", self.ip)
+"""
     assert not _run(source)
 
 
 def test_token_not_flagged_not_in_oep30():
     """'token' is not an OEP-0030 field — never fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class SessionModel(Model):
-            '''.. pii: Stores session data.'''
-            def log_action(self):
-                log.info("auth: %s", access_token)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SessionModel(Model):
+    '''.. pii: Stores session data.'''
+    def log_action(self):
+        log.info("auth: %s", access_token)
+"""
     assert not _run(source)
 
 
 def test_secret_not_flagged_not_in_oep30():
     """'secret' is not an OEP-0030 field — never fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class ApiModel(Model):
-            '''.. pii: Stores API data.'''
-            def log_action(self):
-                log.info("key: %s", api_secret)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ApiModel(Model):
+    '''.. pii: Stores API data.'''
+    def log_action(self):
+        log.info("key: %s", api_secret)
+"""
     assert not _run(source)
 
 
@@ -438,82 +437,82 @@ def test_secret_not_flagged_not_in_oep30():
 def test_pii_in_print_bare():
     """print(pii_var) inside a pii model fires."""
     source = """\
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def display(self):
-                print(username)                          #=A
-    """
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def display(self):
+        print(username)                          #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_print_fstring():
     """print() with PII in an f-string fires."""
     source = """\
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def display(self):
-                print(f"user: {username}")               #=A
-    """
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def display(self):
+        print(f"user: {username}")               #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_print_guarded():
     """print() with PII inside SQUELCH guard does not fire."""
     source = """\
-        SQUELCH_PII_IN_LOGS = True
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def display(self):
-                if not SQUELCH_PII_IN_LOGS:
-                    print(username)
-    """
+SQUELCH_PII_IN_LOGS = True
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def display(self):
+        if not SQUELCH_PII_IN_LOGS:
+            print(username)
+"""
     assert not _run(source)
 
 
 def test_pii_in_stdout_write():
     """sys.stdout.write() with PII fires."""
     source = """\
-        import sys
-        class Model:
-            pass
-        class ReportModel(Model):
-            '''.. pii: Stores report PII.'''
-            def export(self):
-                sys.stdout.write(email)                  #=A
-    """
+import sys
+class Model:
+    pass
+class ReportModel(Model):
+    '''.. pii: Stores report PII.'''
+    def export(self):
+        sys.stdout.write(email)                  #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_stderr_write():
     """sys.stderr.write() with PII fires."""
     source = """\
-        import sys
-        class Model:
-            pass
-        class ReportModel(Model):
-            '''.. pii: Stores report PII.'''
-            def export(self):
-                sys.stderr.write(username)               #=A
-    """
+import sys
+class Model:
+    pass
+class ReportModel(Model):
+    '''.. pii: Stores report PII.'''
+    def export(self):
+        sys.stderr.write(username)               #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_print_safe_key_not_flagged():
     """Printing user_id (safe surrogate key) does not fire."""
     source = """\
-        class Model:
-            pass
-        class EnrollmentModel(Model):
-            '''.. pii: Stores enrollment data.'''
-            def display(self):
-                print(user_id)
-    """
+class Model:
+    pass
+class EnrollmentModel(Model):
+    '''.. pii: Stores enrollment data.'''
+    def display(self):
+        print(user_id)
+"""
     assert not _run(source)
 
 
@@ -522,209 +521,193 @@ def test_pii_in_print_safe_key_not_flagged():
 def test_pii_in_exception_bare():
     """raise ValueError(pii_var) inside a pii model fires."""
     source = """\
-        class Model:
-            pass
-        class PaymentModel(Model):
-            '''.. pii: Stores payment PII.'''
-            def validate(self):
-                raise ValueError(email)                  #=A
-    """
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        raise ValueError(email)                  #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_exception_fstring():
     """raise ValueError(f-string with PII) fires."""
     source = """\
-        class Model:
-            pass
-        class PaymentModel(Model):
-            '''.. pii: Stores payment PII.'''
-            def validate(self):
-                raise ValueError(f"bad username: {username}")   #=A
-    """
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        raise ValueError(f"bad username: {username}")   #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_pii_in_exception_guarded():
     """Exception with PII inside SQUELCH guard does not fire."""
     source = """\
-        SQUELCH_PII_IN_LOGS = True
-        class Model:
-            pass
-        class PaymentModel(Model):
-            '''.. pii: Stores payment PII.'''
-            def validate(self):
-                if not SQUELCH_PII_IN_LOGS:
-                    raise ValueError(email)
-    """
+SQUELCH_PII_IN_LOGS = True
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        if not SQUELCH_PII_IN_LOGS:
+            raise ValueError(email)
+"""
     assert not _run(source)
 
 
 def test_pii_in_exception_safe_key():
     """raise ValueError(user_id) does not fire (safe surrogate key)."""
     source = """\
-        class Model:
-            pass
-        class PaymentModel(Model):
-            '''.. pii: Stores payment PII.'''
-            def validate(self):
-                raise ValueError(user_id)
-    """
+class Model:
+    pass
+class PaymentModel(Model):
+    '''.. pii: Stores payment PII.'''
+    def validate(self):
+        raise ValueError(user_id)
+"""
     assert not _run(source)
 
 
 def test_non_sink_call_not_flagged():
     """Arbitrary function calls with PII are not flagged."""
     source = """\
-        class Model:
-            pass
-        class UserModel(Model):
-            '''.. pii: Stores user PII.'''
-            def process(self):
-                some_function(email)
-    """
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def process(self):
+        some_function(email)
+"""
     assert not _run(source)
 
 
-# -- Scope: out-of-model code is not checked ----------------------------------
+# -- Scope: global (whole-module) checking ------------------------------------
 
-def test_standalone_function_not_checked():
-    """Logs inside a standalone function (not a model method) are not checked."""
+def test_standalone_function_checked():
+    """Logs inside a standalone function are checked."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        def standalone_helper(email):
-            log.info(email)
-    """
-    assert not _run(source)
+import logging
+log = logging.getLogger(__name__)
+def standalone_helper(email):
+    log.info(email)
+"""
+    assert _has(_run(source), "4")
 
 
-def test_module_level_print_not_checked():
-    """Module-level print() is not checked."""
+def test_module_level_print_checked():
+    """Module-level print() is checked."""
     source = """\
-        print(username)
-    """
-    assert not _run(source)
+print(username)
+"""
+    assert _has(_run(source), "1")
 
 
-def test_module_level_raise_not_checked():
-    """Module-level raise is not checked."""
+def test_module_level_raise_checked():
+    """Module-level raise is checked."""
     source = """\
-        raise ValueError(email)
-    """
-    assert not _run(source)
+raise ValueError(email)
+"""
+    assert _has(_run(source), "1")
 
 
-# -- Scope: .. no_pii: models are skipped -------------------------------------
+# -- Scope: .. no_pii: does not exempt sink checks ----------------------------
 
-def test_squelch_exempt_in_no_pii_model():
-    """Logs inside a .. no_pii: model are entirely skipped."""
+def test_squelch_enforced_in_no_pii_model():
+    """.. no_pii: does not exempt sink checks; unguarded sink still fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class SafeModel(Model):
-            '''.. no_pii: This model holds no PII.'''
-            email = None
-            def log_something(self):
-                log.info(self.email)
-    """
-    assert not _run(source)
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SafeModel(Model):
+    '''.. no_pii: This model holds no PII.'''
+    email = None
+    def log_something(self):
+        log.info(self.email)
+"""
+    assert _has(_run(source), "9")
 
 
 def test_squelch_enforced_in_pii_model():
     """Unguarded PII log inside a .. pii: model fires."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UnsafeModel(Model):
-            '''.. pii: Stores user PII.'''
-            email = None
-            def log_something(self):
-                log.info(self.email)                     #=A
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UnsafeModel(Model):
+    '''.. pii: Stores user PII.'''
+    email = None
+    def log_something(self):
+        log.info(self.email)                     #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_squelch_enforced_in_unannotated_model():
     """Unguarded PII log inside a model with no annotation fires (conservative)."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UnannotatedModel(Model):
-            email = None
-            def log_something(self):
-                log.info(self.email)                     #=A
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UnannotatedModel(Model):
+    email = None
+    def log_something(self):
+        log.info(self.email)                     #=A
+"""
     assert _has(_run(source), "A")
 
 
 def test_squelch_enforced_guarded_in_pii_model():
     """Properly guarded PII log inside a .. pii: model does not fire."""
     source = """\
-        import logging
-        SQUELCH_PII_IN_LOGS = True
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class UnsafeModel(Model):
-            '''.. pii: Stores user PII.'''
-            email = None
-            def log_something(self):
-                if not SQUELCH_PII_IN_LOGS:
-                    log.info(self.email)
-    """
+import logging
+SQUELCH_PII_IN_LOGS = True
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UnsafeModel(Model):
+    '''.. pii: Stores user PII.'''
+    email = None
+    def log_something(self):
+        if not SQUELCH_PII_IN_LOGS:
+            log.info(self.email)
+"""
     assert not _run(source)
 
 
 def test_pii_in_log_new_safe_keys_not_flagged():
     """CI-discovered safe keys do not trigger a warning."""
     source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class SafeKeyModel(Model):
-            '''.. pii: Stores user PII.'''
-            service_username = None
-            email_enabled = None
-            email_sent_on = None
-            require_course_email_auth = None
-            attr_full_name = None
-            proctoring_escalation_email = None
-            email_cadence = None
-            def notify(self):
-                log.info(self.service_username)
-                log.info(self.email_enabled)
-                log.info(self.email_sent_on)
-                log.info(self.require_course_email_auth)
-                log.info(self.attr_full_name)
-                log.info(self.proctoring_escalation_email)
-                log.info(self.email_cadence)
-    """
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SafeKeyModel(Model):
+    '''.. pii: Stores user PII.'''
+    service_username = None
+    email_enabled = None
+    email_sent_on = None
+    require_course_email_auth = None
+    attr_full_name = None
+    location = None
+    _location = None
+    proctoring_escalation_email = None
+    email_cadence = None
+    def notify(self):
+        log.info(self.service_username)
+        log.info(self.email_enabled)
+        log.info(self.email_sent_on)
+        log.info(self.require_course_email_auth)
+        log.info(self.attr_full_name)
+        log.info(self.location)
+        log.info(self._location)
+        log.info(self.proctoring_escalation_email)
+        log.info(self.email_cadence)
+"""
     assert not _run(source)
-
-
-def test_pii_in_log_location_and__location_flagged():
-    """location and _location are treated as PII terms and should fire."""
-    source = """\
-        import logging
-        log = logging.getLogger(__name__)
-        class Model:
-            pass
-        class ProfileModel(Model):
-            '''.. pii: Stores learner profile PII.'''
-            location = None
-            _location = None
-            def log_profile(self):
-                log.info(self.location)             #=A
-                log.info(self._location)            #=B
-    """
-    messages = _run(source)
-    assert _has(messages, "A")
-    assert _has(messages, "B")

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -676,3 +676,29 @@ class UnsafeModel(Model):
             log.info(self.email)
 """
     assert not _run(source)
+
+
+def test_pii_in_log_new_safe_keys_not_flagged():
+    """CI-discovered safe keys do not trigger a warning."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SafeKeyModel(Model):
+    '''.. pii: Stores user PII.'''
+    service_username = None
+    email_enabled = None
+    email_sent_on = None
+    require_course_email_auth = None
+    attr_full_name = None
+    location = None
+    def notify(self):
+        log.info(self.service_username)
+        log.info(self.email_enabled)
+        log.info(self.email_sent_on)
+        log.info(self.require_course_email_auth)
+        log.info(self.attr_full_name)
+        log.info(self.location)
+"""
+    assert not _run(source)

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -19,8 +19,6 @@ Message format produced by run_pylint:
 e.g.  "A:pii-missing-squelch:Log call exposes PII term 'email' without ..."
 """
 
-import pytest
-
 from .pylint_test import run_pylint
 
 

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -693,6 +693,9 @@ class SafeKeyModel(Model):
     require_course_email_auth = None
     attr_full_name = None
     location = None
+    _location = None
+    proctoring_escalation_email = None
+    email_cadence = None
     def notify(self):
         log.info(self.service_username)
         log.info(self.email_enabled)
@@ -700,5 +703,8 @@ class SafeKeyModel(Model):
         log.info(self.require_course_email_auth)
         log.info(self.attr_full_name)
         log.info(self.location)
+        log.info(self._location)
+        log.info(self.proctoring_escalation_email)
+        log.info(self.email_cadence)
 """
     assert not _run(source)

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -22,223 +22,223 @@ def _has(messages, marker):
 def test_pii_in_log_bare_name():
     """Unguarded PII variable in log.info fires."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        log.info("user: %s", email)          #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                log.info("user: %s", email)          #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_fstring():
     """PII inside an f-string in a log call fires."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        log.warning(f"email: {email}")       #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                log.warning(f"email: {email}")       #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_attribute_access():
     """self.email passed to log fires."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    email = None
-    def notify(self):
-        log.error("failed: %s", self.email)  #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            email = None
+            def notify(self):
+                log.error("failed: %s", self.email)  #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_nested_in_dict():
     """PII inside a dict value passed to log fires."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        log.info("%s", {"email": email})     #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                log.info("%s", {"email": email})     #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_string_literal_not_flagged():
     """String literals containing PII words are not flagged (not actual PII values)."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        log.info("user email: unknown")
-        log.info("Email field is required")
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                log.info("user email: unknown")
+                log.info("Email field is required")
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_bare_flag():
     """PII log inside ``if not SQUELCH_PII_IN_LOGS:`` is safe."""
     source = """\
-import logging
-SQUELCH_PII_IN_LOGS = True
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        if not SQUELCH_PII_IN_LOGS:
-            log.info("email=%s", email)
-"""
+        import logging
+        SQUELCH_PII_IN_LOGS = True
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                if not SQUELCH_PII_IN_LOGS:
+                    log.info("email=%s", email)
+    """
     assert not _run(source)
 
 
-def test_pii_in_log_guarded_by_flag_positive():
-    """PII log in else-branch of ``if SQUELCH_PII_IN_LOGS:`` is safe."""
+def test_pii_in_log_in_else_branch_of_squelch_guard():
+    """PII log in the else-branch of ``if SQUELCH_PII_IN_LOGS:`` is safe."""
     source = """\
-import logging
-SQUELCH_PII_IN_LOGS = True
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        if SQUELCH_PII_IN_LOGS:
-            log.info("user_id=%s", user_id)
-        else:
-            log.info("email=%s", email)
-"""
+        import logging
+        SQUELCH_PII_IN_LOGS = True
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                if SQUELCH_PII_IN_LOGS:
+                    log.info("user_id=%s", user_id)
+                else:
+                    log.info("email=%s", email)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_features_subscript():
     """settings.FEATURES['SQUELCH_PII_IN_LOGS'] guard is recognised."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        if not settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-            log.info("email=%s", email)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                if not settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+                    log.info("email=%s", email)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_features_get():
     """settings.FEATURES.get('SQUELCH_PII_IN_LOGS') guard is recognised."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        if not settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):
-            log.info("username=%s", username)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                if not settings.FEATURES.get('SQUELCH_PII_IN_LOGS'):
+                    log.info("username=%s", username)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_settings_attribute():
     """settings.SQUELCH_PII_IN_LOGS guard is recognised."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        if not settings.SQUELCH_PII_IN_LOGS:
-            log.info("phone=%s", phone_number)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                if not settings.SQUELCH_PII_IN_LOGS:
+                    log.info("phone=%s", phone_number)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_getattr_settings():
     """getattr(settings, 'SQUELCH_PII_IN_LOGS', False) guard is recognised."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
-            log.info("email=%s", email)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
+                    log.info("email=%s", email)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_guarded_by_not_getattr_settings():
     """``if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):`` guard is recognised."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
-            log.info("username=%s", username)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
+                    log.info("username=%s", username)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_safe_key_not_flagged():
     """Surrogate key user_id is not flagged."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class EnrollmentModel(Model):
-    '''.. pii: Stores enrollment data.'''
-    def log_action(self):
-        log.info("enrolled user_id=%s", user_id)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class EnrollmentModel(Model):
+            '''.. pii: Stores enrollment data.'''
+            def log_action(self):
+                log.info("enrolled user_id=%s", user_id)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_non_pii_name_not_flagged():
     """Non-PII variable names are not flagged."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class CourseModel(Model):
-    '''.. pii: Stores course data.'''
-    def log_action(self):
-        log.info("enrolled course: %s", course_data)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class CourseModel(Model):
+            '''.. pii: Stores course data.'''
+            def log_action(self):
+                log.info("enrolled course: %s", course_data)
+    """
     assert not _run(source)
 
 
@@ -261,15 +261,15 @@ def test_pii_in_log_multiple_levels():
 def test_pii_in_log_inline_disable_suppresses():
     """Inline pylint:disable=pii-missing-squelch suppresses the warning."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        log.info("email=%s", email)  # pylint: disable=pii-missing-squelch
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def notify(self):
+                log.info("email=%s", email)  # pylint: disable=pii-missing-squelch
+    """
     assert not _run(source)
 
 
@@ -278,62 +278,62 @@ class UserModel(Model):
 def test_pii_in_log_job_title_fires():
     """job_title fires (OEP-0030 PII term)."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class ProfileModel(Model):
-    '''.. pii: Stores learner profile PII.'''
-    def log_profile(self):
-        log.info("user info: %s", job_title)     #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class ProfileModel(Model):
+            '''.. pii: Stores learner profile PII.'''
+            def log_profile(self):
+                log.info("user info: %s", job_title)     #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_social_link_fires():
     """social_link fires (OEP-0030 PII term — explicit form)."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class ProfileModel(Model):
-    '''.. pii: Stores learner profile PII.'''
-    def log_profile(self):
-        log.info("link: %s", social_link)        #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class ProfileModel(Model):
+            '''.. pii: Stores learner profile PII.'''
+            def log_profile(self):
+                log.info("link: %s", social_link)        #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_profile_image_fires():
     """profile_image fires (OEP-0030 PII term — explicit form)."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class ProfileModel(Model):
-    '''.. pii: Stores learner profile PII.'''
-    profile_image = None
-    def log_profile(self):
-        log.info("img: %s", self.profile_image)  #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class ProfileModel(Model):
+            '''.. pii: Stores learner profile PII.'''
+            profile_image = None
+            def log_profile(self):
+                log.info("img: %s", self.profile_image)  #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_log_ip_address_fires():
     """ip_address fires (OEP-0030 PII term — explicit form)."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class SessionModel(Model):
-    '''.. pii: Stores session PII.'''
-    ip_address = None
-    def log_session(self):
-        log.info("ip: %s", self.ip_address)      #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class SessionModel(Model):
+            '''.. pii: Stores session PII.'''
+            ip_address = None
+            def log_session(self):
+                log.info("ip: %s", self.ip_address)      #=A
+    """
     assert _has(_run(source), "A")
 
 
@@ -342,94 +342,94 @@ class SessionModel(Model):
 def test_bare_name_not_flagged():
     """self.name inside a PII model does NOT fire — 'name' removed from defaults."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    name = None
-    def log_action(self):
-        log.info("item: %s", self.name)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            name = None
+            def log_action(self):
+                log.info("item: %s", self.name)
+    """
     assert not _run(source)
 
 
 def test_bare_title_not_flagged():
     """self.title inside a PII model does NOT fire — bare 'title' removed from defaults."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class ProfileModel(Model):
-    '''.. pii: Stores learner profile PII.'''
-    title = None
-    def log_profile(self):
-        log.info("user: %s", self.title)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class ProfileModel(Model):
+            '''.. pii: Stores learner profile PII.'''
+            title = None
+            def log_profile(self):
+                log.info("user: %s", self.title)
+    """
     assert not _run(source)
 
 
 def test_bare_image_not_flagged():
     """self.image inside a PII model does NOT fire — generic 'image' removed from defaults."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class CourseModel(Model):
-    '''.. pii: Stores course data.'''
-    image = None
-    def log_course(self):
-        log.info("img: %s", self.image)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class CourseModel(Model):
+            '''.. pii: Stores course data.'''
+            image = None
+            def log_course(self):
+                log.info("img: %s", self.image)
+    """
     assert not _run(source)
 
 
 def test_bare_ip_not_flagged():
     """self.ip inside a PII model does NOT fire — bare 'ip' removed from defaults."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class SessionModel(Model):
-    '''.. pii: Stores session PII.'''
-    ip = None
-    def log_session(self):
-        log.info("ip: %s", self.ip)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class SessionModel(Model):
+            '''.. pii: Stores session PII.'''
+            ip = None
+            def log_session(self):
+                log.info("ip: %s", self.ip)
+    """
     assert not _run(source)
 
 
 def test_token_not_flagged_not_in_oep30():
     """'token' is not an OEP-0030 field — never fires."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class SessionModel(Model):
-    '''.. pii: Stores session data.'''
-    def log_action(self):
-        log.info("auth: %s", access_token)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class SessionModel(Model):
+            '''.. pii: Stores session data.'''
+            def log_action(self):
+                log.info("auth: %s", access_token)
+    """
     assert not _run(source)
 
 
 def test_secret_not_flagged_not_in_oep30():
     """'secret' is not an OEP-0030 field — never fires."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class ApiModel(Model):
-    '''.. pii: Stores API data.'''
-    def log_action(self):
-        log.info("key: %s", api_secret)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class ApiModel(Model):
+            '''.. pii: Stores API data.'''
+            def log_action(self):
+                log.info("key: %s", api_secret)
+    """
     assert not _run(source)
 
 
@@ -438,82 +438,82 @@ class ApiModel(Model):
 def test_pii_in_print_bare():
     """print(pii_var) inside a pii model fires."""
     source = """\
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def display(self):
-        print(username)                          #=A
-"""
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def display(self):
+                print(username)                          #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_print_fstring():
     """print() with PII in an f-string fires."""
     source = """\
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def display(self):
-        print(f"user: {username}")               #=A
-"""
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def display(self):
+                print(f"user: {username}")               #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_print_guarded():
     """print() with PII inside SQUELCH guard does not fire."""
     source = """\
-SQUELCH_PII_IN_LOGS = True
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def display(self):
-        if not SQUELCH_PII_IN_LOGS:
-            print(username)
-"""
+        SQUELCH_PII_IN_LOGS = True
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def display(self):
+                if not SQUELCH_PII_IN_LOGS:
+                    print(username)
+    """
     assert not _run(source)
 
 
 def test_pii_in_stdout_write():
     """sys.stdout.write() with PII fires."""
     source = """\
-import sys
-class Model:
-    pass
-class ReportModel(Model):
-    '''.. pii: Stores report PII.'''
-    def export(self):
-        sys.stdout.write(email)                  #=A
-"""
+        import sys
+        class Model:
+            pass
+        class ReportModel(Model):
+            '''.. pii: Stores report PII.'''
+            def export(self):
+                sys.stdout.write(email)                  #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_stderr_write():
     """sys.stderr.write() with PII fires."""
     source = """\
-import sys
-class Model:
-    pass
-class ReportModel(Model):
-    '''.. pii: Stores report PII.'''
-    def export(self):
-        sys.stderr.write(username)               #=A
-"""
+        import sys
+        class Model:
+            pass
+        class ReportModel(Model):
+            '''.. pii: Stores report PII.'''
+            def export(self):
+                sys.stderr.write(username)               #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_print_safe_key_not_flagged():
     """Printing user_id (safe surrogate key) does not fire."""
     source = """\
-class Model:
-    pass
-class EnrollmentModel(Model):
-    '''.. pii: Stores enrollment data.'''
-    def display(self):
-        print(user_id)
-"""
+        class Model:
+            pass
+        class EnrollmentModel(Model):
+            '''.. pii: Stores enrollment data.'''
+            def display(self):
+                print(user_id)
+    """
     assert not _run(source)
 
 
@@ -522,67 +522,67 @@ class EnrollmentModel(Model):
 def test_pii_in_exception_bare():
     """raise ValueError(pii_var) inside a pii model fires."""
     source = """\
-class Model:
-    pass
-class PaymentModel(Model):
-    '''.. pii: Stores payment PII.'''
-    def validate(self):
-        raise ValueError(email)                  #=A
-"""
+        class Model:
+            pass
+        class PaymentModel(Model):
+            '''.. pii: Stores payment PII.'''
+            def validate(self):
+                raise ValueError(email)                  #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_exception_fstring():
     """raise ValueError(f-string with PII) fires."""
     source = """\
-class Model:
-    pass
-class PaymentModel(Model):
-    '''.. pii: Stores payment PII.'''
-    def validate(self):
-        raise ValueError(f"bad username: {username}")   #=A
-"""
+        class Model:
+            pass
+        class PaymentModel(Model):
+            '''.. pii: Stores payment PII.'''
+            def validate(self):
+                raise ValueError(f"bad username: {username}")   #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_pii_in_exception_guarded():
     """Exception with PII inside SQUELCH guard does not fire."""
     source = """\
-SQUELCH_PII_IN_LOGS = True
-class Model:
-    pass
-class PaymentModel(Model):
-    '''.. pii: Stores payment PII.'''
-    def validate(self):
-        if not SQUELCH_PII_IN_LOGS:
-            raise ValueError(email)
-"""
+        SQUELCH_PII_IN_LOGS = True
+        class Model:
+            pass
+        class PaymentModel(Model):
+            '''.. pii: Stores payment PII.'''
+            def validate(self):
+                if not SQUELCH_PII_IN_LOGS:
+                    raise ValueError(email)
+    """
     assert not _run(source)
 
 
 def test_pii_in_exception_safe_key():
     """raise ValueError(user_id) does not fire (safe surrogate key)."""
     source = """\
-class Model:
-    pass
-class PaymentModel(Model):
-    '''.. pii: Stores payment PII.'''
-    def validate(self):
-        raise ValueError(user_id)
-"""
+        class Model:
+            pass
+        class PaymentModel(Model):
+            '''.. pii: Stores payment PII.'''
+            def validate(self):
+                raise ValueError(user_id)
+    """
     assert not _run(source)
 
 
 def test_non_sink_call_not_flagged():
     """Arbitrary function calls with PII are not flagged."""
     source = """\
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def process(self):
-        some_function(email)
-"""
+        class Model:
+            pass
+        class UserModel(Model):
+            '''.. pii: Stores user PII.'''
+            def process(self):
+                some_function(email)
+    """
     assert not _run(source)
 
 
@@ -591,27 +591,27 @@ class UserModel(Model):
 def test_standalone_function_not_checked():
     """Logs inside a standalone function (not a model method) are not checked."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-def standalone_helper(email):
-    log.info(email)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        def standalone_helper(email):
+            log.info(email)
+    """
     assert not _run(source)
 
 
 def test_module_level_print_not_checked():
     """Module-level print() is not checked."""
     source = """\
-print(username)
-"""
+        print(username)
+    """
     assert not _run(source)
 
 
 def test_module_level_raise_not_checked():
     """Module-level raise is not checked."""
     source = """\
-raise ValueError(email)
-"""
+        raise ValueError(email)
+    """
     assert not _run(source)
 
 
@@ -620,95 +620,95 @@ raise ValueError(email)
 def test_squelch_exempt_in_no_pii_model():
     """Logs inside a .. no_pii: model are entirely skipped."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class SafeModel(Model):
-    '''.. no_pii: This model holds no PII.'''
-    email = None
-    def log_something(self):
-        log.info(self.email)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class SafeModel(Model):
+            '''.. no_pii: This model holds no PII.'''
+            email = None
+            def log_something(self):
+                log.info(self.email)
+    """
     assert not _run(source)
 
 
 def test_squelch_enforced_in_pii_model():
     """Unguarded PII log inside a .. pii: model fires."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UnsafeModel(Model):
-    '''.. pii: Stores user PII.'''
-    email = None
-    def log_something(self):
-        log.info(self.email)                     #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UnsafeModel(Model):
+            '''.. pii: Stores user PII.'''
+            email = None
+            def log_something(self):
+                log.info(self.email)                     #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_squelch_enforced_in_unannotated_model():
     """Unguarded PII log inside a model with no annotation fires (conservative)."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UnannotatedModel(Model):
-    email = None
-    def log_something(self):
-        log.info(self.email)                     #=A
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UnannotatedModel(Model):
+            email = None
+            def log_something(self):
+                log.info(self.email)                     #=A
+    """
     assert _has(_run(source), "A")
 
 
 def test_squelch_enforced_guarded_in_pii_model():
     """Properly guarded PII log inside a .. pii: model does not fire."""
     source = """\
-import logging
-SQUELCH_PII_IN_LOGS = True
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UnsafeModel(Model):
-    '''.. pii: Stores user PII.'''
-    email = None
-    def log_something(self):
-        if not SQUELCH_PII_IN_LOGS:
-            log.info(self.email)
-"""
+        import logging
+        SQUELCH_PII_IN_LOGS = True
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class UnsafeModel(Model):
+            '''.. pii: Stores user PII.'''
+            email = None
+            def log_something(self):
+                if not SQUELCH_PII_IN_LOGS:
+                    log.info(self.email)
+    """
     assert not _run(source)
 
 
 def test_pii_in_log_new_safe_keys_not_flagged():
     """CI-discovered safe keys do not trigger a warning."""
     source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class SafeKeyModel(Model):
-    '''.. pii: Stores user PII.'''
-    service_username = None
-    email_enabled = None
-    email_sent_on = None
-    require_course_email_auth = None
-    attr_full_name = None
-    location = None
-    _location = None
-    proctoring_escalation_email = None
-    email_cadence = None
-    def notify(self):
-        log.info(self.service_username)
-        log.info(self.email_enabled)
-        log.info(self.email_sent_on)
-        log.info(self.require_course_email_auth)
-        log.info(self.attr_full_name)
-        log.info(self.location)
-        log.info(self._location)
-        log.info(self.proctoring_escalation_email)
-        log.info(self.email_cadence)
-"""
+        import logging
+        log = logging.getLogger(__name__)
+        class Model:
+            pass
+        class SafeKeyModel(Model):
+            '''.. pii: Stores user PII.'''
+            service_username = None
+            email_enabled = None
+            email_sent_on = None
+            require_course_email_auth = None
+            attr_full_name = None
+            location = None
+            _location = None
+            proctoring_escalation_email = None
+            email_cadence = None
+            def notify(self):
+                log.info(self.service_username)
+                log.info(self.email_enabled)
+                log.info(self.email_sent_on)
+                log.info(self.require_course_email_auth)
+                log.info(self.attr_full_name)
+                log.info(self.location)
+                log.info(self._location)
+                log.info(self.proctoring_escalation_email)
+                log.info(self.email_cadence)
+    """
     assert not _run(source)

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -273,24 +273,8 @@ class ProfileModel(Model):
     assert _has(_run(source), "A")
 
 
-def test_pii_in_log_title_attribute_fires():
-    """self.title fires (OEP-0030: Job title is PII)."""
-    source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class ProfileModel(Model):
-    '''.. pii: Stores learner profile PII.'''
-    title = None
-    def log_profile(self):
-        log.info("user: %s", self.title)         #=A
-"""
-    assert _has(_run(source), "A")
-
-
-def test_pii_in_log_social_fires():
-    """social_link fires (OEP-0030 PII term)."""
+def test_pii_in_log_social_link_fires():
+    """social_link fires (OEP-0030 PII term — explicit form)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -304,8 +288,8 @@ class ProfileModel(Model):
     assert _has(_run(source), "A")
 
 
-def test_pii_in_log_website_fires():
-    """user_website fires (OEP-0030 PII term)."""
+def test_pii_in_log_profile_image_fires():
+    """profile_image fires (OEP-0030 PII term — explicit form)."""
     source = """\
 import logging
 log = logging.getLogger(__name__)
@@ -313,10 +297,93 @@ class Model:
     pass
 class ProfileModel(Model):
     '''.. pii: Stores learner profile PII.'''
+    profile_image = None
     def log_profile(self):
-        log.info("site: %s", user_website)       #=A
+        log.info("img: %s", self.profile_image)  #=A
 """
     assert _has(_run(source), "A")
+
+
+def test_pii_in_log_ip_address_fires():
+    """ip_address fires (OEP-0030 PII term — explicit form)."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SessionModel(Model):
+    '''.. pii: Stores session PII.'''
+    ip_address = None
+    def log_session(self):
+        log.info("ip: %s", self.ip_address)      #=A
+"""
+    assert _has(_run(source), "A")
+
+
+# -- Curated exclusions: formerly-generic terms no longer fire by default -----
+
+def test_bare_name_not_flagged():
+    """self.name inside a PII model does NOT fire — 'name' removed from defaults."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    name = None
+    def log_action(self):
+        log.info("item: %s", self.name)
+"""
+    assert not _run(source)
+
+
+def test_bare_title_not_flagged():
+    """self.title inside a PII model does NOT fire — bare 'title' removed from defaults."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class ProfileModel(Model):
+    '''.. pii: Stores learner profile PII.'''
+    title = None
+    def log_profile(self):
+        log.info("user: %s", self.title)
+"""
+    assert not _run(source)
+
+
+def test_bare_image_not_flagged():
+    """self.image inside a PII model does NOT fire — generic 'image' removed from defaults."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class CourseModel(Model):
+    '''.. pii: Stores course data.'''
+    image = None
+    def log_course(self):
+        log.info("img: %s", self.image)
+"""
+    assert not _run(source)
+
+
+def test_bare_ip_not_flagged():
+    """self.ip inside a PII model does NOT fire — bare 'ip' removed from defaults."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class SessionModel(Model):
+    '''.. pii: Stores session PII.'''
+    ip = None
+    def log_session(self):
+        log.info("ip: %s", self.ip)
+"""
+    assert not _run(source)
 
 
 def test_token_not_flagged_not_in_oep30():

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -212,21 +212,6 @@ class UserModel(Model):
     assert not _run(source)
 
 
-def test_pii_in_log_safe_function_wrapping():
-    """PII wrapped in redact() is not flagged."""
-    source = """\
-import logging
-log = logging.getLogger(__name__)
-class Model:
-    pass
-class UserModel(Model):
-    '''.. pii: Stores user PII.'''
-    def notify(self):
-        log.info("value=%s", redact(email))
-"""
-    assert not _run(source)
-
-
 def test_pii_in_log_safe_key_not_flagged():
     """Surrogate key user_id is not flagged."""
     source = """\
@@ -571,19 +556,6 @@ class PaymentModel(Model):
     def validate(self):
         if not SQUELCH_PII_IN_LOGS:
             raise ValueError(email)
-"""
-    assert not _run(source)
-
-
-def test_pii_in_exception_safe_function():
-    """raise ValueError(redact(pii)) does not fire."""
-    source = """\
-class Model:
-    pass
-class PaymentModel(Model):
-    '''.. pii: Stores payment PII.'''
-    def validate(self):
-        raise ValueError(redact(email))
 """
     assert not _run(source)
 

--- a/test/plugins/test_pii_squelch_check.py
+++ b/test/plugins/test_pii_squelch_check.py
@@ -180,6 +180,38 @@ class UserModel(Model):
     assert not _run(source)
 
 
+def test_pii_in_log_guarded_by_getattr_settings():
+    """getattr(settings, 'SQUELCH_PII_IN_LOGS', False) guard is recognised."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
+            log.info("email=%s", email)
+"""
+    assert not _run(source)
+
+
+def test_pii_in_log_guarded_by_not_getattr_settings():
+    """``if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):`` guard is recognised."""
+    source = """\
+import logging
+log = logging.getLogger(__name__)
+class Model:
+    pass
+class UserModel(Model):
+    '''.. pii: Stores user PII.'''
+    def notify(self):
+        if not getattr(settings, 'SQUELCH_PII_IN_LOGS', False):
+            log.info("username=%s", username)
+"""
+    assert not _run(source)
+
+
 def test_pii_in_log_safe_function_wrapping():
     """PII wrapped in redact() is not flagged."""
     source = """\


### PR DESCRIPTION
### Description:
PII variables (e.g. email, username, full_name) could silently leak into logs, print statements, or exceptions with no automated guardrail. Stale `.. no_pii`: annotations on Django models also went undetected.

### Solution:

- Replaced vague words (name, ip, image) with specific ones (full_name, ip_address, profile_image) so common variable names don't trigger false alerts.
- Added 21 known-safe field names (e.g., service_username, email_enabled, attr_full_name, location) to an ignore list so they are always skipped.
- Updated the same lists in 3 places: the plugin code, the runtime defaults, and the pylintrc template — so nothing goes out of date.
- New test cases lock in this behavior so these false positives can never come back.
- A field literally named email (but it's actually a BooleanField) still flags. Developers just need to add one inline comment to silence it:

```
python
# pylint: disable=pii-invalid-no-pii-annotation

```

### Private JIRA Ticket:
[BOMS-587](https://2u-internal.atlassian.net/browse/BOMS-587)