### PR TITLE
chore: relax the social-auth-app-django pin

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -22,5 +22,5 @@ elasticsearch<7.14.0
 # 2026-07-06: Constrain social-auth-* packages to the latest version compatible with
 # edx-drf-extensions<=10.6.0. (Newer versions require a POST instead of a GET.)
 # Tracking issue: https://github.com/openedx/edx-drf-extensions/issues/561
-social-auth-app-django>=5.9.0,<6.0.0
+social-auth-app-django>=5.4.1,<6.0.0
 social-auth-core>=4.9.1,<5.0.0


### PR DESCRIPTION
\>=5.9.0 was too strict.  openedx-platform still [uses and pins 5.4.1](https://github.com/openedx/openedx-platform/blob/5aa8bb2/requirements/constraints.txt#L98).