### PR TITLE
fix: remove all lower bounds in common_constraints.txt

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -22,5 +22,5 @@ elasticsearch<7.14.0
 # 2026-07-06: Constrain social-auth-* packages to the latest version compatible with
 # edx-drf-extensions<=10.6.0. (Newer versions require a POST instead of a GET.)
 # Tracking issue: https://github.com/openedx/edx-drf-extensions/issues/561
-social-auth-app-django>=5.4.1,<6.0.0
-social-auth-core>=4.9.1,<5.0.0
+social-auth-app-django<6.0.0
+social-auth-core<5.0.0


### PR DESCRIPTION
This file should generally not specify lower bounds.  This is being problematic for the 2U fork of openedx-platform which still uses an even older social-auth-core which we're not quite ready to upgrade.

And yes, we should probably also just switch to maintaining our own 2U-specific global common_constraints.txt but that's ideally a conversation we can defer.